### PR TITLE
kmax: klocalizer: fix the bug preventing reproducibility

### DIFF
--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -337,7 +337,7 @@ def get_arch_specific_constraints(arch, architecture_configs):
     arch_var = "CONFIG_%s" % (arch.upper())
     constraints = [ z3.Bool(arch_var) ]
     disabled = architecture_configs.difference(set([ arch_var ]))
-  disabled_z3 = [ z3.Not(z3.Bool(var)) for var in disabled ]
+  disabled_z3 = [ z3.Not(z3.Bool(var)) for var in sorted(disabled) ]
   return constraints + disabled_z3
 
 if __name__ == '__main__':    


### PR DESCRIPTION
Python sets are not ordered by default. Although the set equality is
satisfied in different runs, traversing the set in different orders leads
klocalizer to produce different outputs in different runs. Although these
outputs are equivalent in terms of successfully building the compilation
units in question, the difference in config files prevents reproducibility.

Traverse over ordered set instead to fix the issue.