### PR TITLE
kclause: introduce composite kclause formulas file format to boost performance

### DIFF
--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -38,7 +38,13 @@ def get_kextract(kextract_file):
         lists.append(line.split())
       return lists
   
-def get_kclause_constraints(kclause_file):
+def get_kclause_constraints(kclause_file, is_file_composite):
+  # composite: a list of constraints
+  if is_file_composite:
+    return z3.parse_smt2_file(kclause_file)
+
+  # not composite: it is a mapping from config options to constraints
+  # thus, parse it
   with open(kclause_file, 'rb') as fp:
     # kclause, defined_vars, used_vars = pickle.load(fp)
     kclause = pickle.load(fp)
@@ -354,6 +360,10 @@ if __name__ == '__main__':
                          type=str,
                          default=None,
                          help="""The file containing the a pickled tuple with a mapping from configuration option to its formulas and a list of additional constraints.  This overrides --arch.""")
+  argparser.add_argument('--use-composite-kclause-formulas-files',
+                         action="store_true",
+                         help="""Use composite kclause formulas files where all constraints are in a single list instead of a mapping from configuration option to its formulas. """
+                              """This reduces the time spent on parsing the kclause formulas file, hence, increases the performance. The input kclause formulas file needs to be in composite format. """)
   argparser.add_argument('--kextract',
                          type=str,
                          default=None,
@@ -441,6 +451,7 @@ if __name__ == '__main__':
   formulas = args.formulas
   kmax_file = args.kmax_formulas
   kclause_file = args.kclause_formulas
+  use_composite_kclause_formulas_files = args.use_composite_kclause_formulas_files
   kextract_file = args.kextract
   archs = args.arch
   allarchs = args.all
@@ -749,7 +760,7 @@ if __name__ == '__main__':
           constraints.extend( z3.parse_smt2_string(f.read()) )
 
       # add kclause constraints
-      constraints.extend(get_kclause_constraints(kclause_file))
+      constraints.extend(get_kclause_constraints(kclause_file, use_composite_kclause_formulas_files))
 
       user_constraints = []
       

--- a/scripts/kclause_to_composite.py
+++ b/scripts/kclause_to_composite.py
@@ -1,0 +1,39 @@
+import z3, pickle, os, glob, argparse
+
+parser = argparse.ArgumentParser(description="Create composite kclause formulas files from kclause files in place.")
+helptxt="The path to the .kmax folder in which the kclause formulas files are to be converted to composite kclause formulas files."
+parser.add_argument('-k', '--kmax-path', default=None, type=str, required=True, help=helptxt)
+kmax_path = parser.parse_args().kmax_path
+
+assert os.path.exists(kmax_path) and os.path.isdir(kmax_path)
+
+all_kclause_files = glob.glob(os.path.join(kmax_path, "kclause", "*", "kclause"))
+
+for f in all_kclause_files:
+    assert os.path.isfile(f)
+
+for kclause_file in all_kclause_files:
+    print("Processing %s" % kclause_file)
+    with open(kclause_file, 'rb') as fp:
+        kclause = pickle.load(fp)
+
+        kclause_constraints = {}
+        for var in kclause.keys():
+            kclause_constraints[var] = [ z3.parse_smt2_string(clause) for clause in kclause[var] ]
+
+        vec = z3.AstVector()
+        for var in kclause_constraints.keys():
+            for z3_clause in kclause_constraints[var]:
+                for cl in z3_clause:
+                    vec.push(cl)
+        
+        constraints = vec
+
+        solver = z3.Solver()
+        solver.add(constraints)
+
+        composite_kclause_file = kclause_file
+        with open(composite_kclause_file, 'w') as fp:
+            fp.write(solver.to_smt2())
+        print("Written the composite kclause file to '%s'" % composite_kclause_file)
+        


### PR DESCRIPTION
Currently, kclause files are dictionaries, which are needed to be parsed
by klocalizer on each run such that each clause in the dictionary is
accumulated to a constraints list. This process has a great share on
the overall running time the kclause by almost doubling it.

Create a new kclause format, i.e., composite kclause, which takes away
the need for traversing a dictionary, and instead stores the composite
clauses already accumuluated in a list.

kmax/klocalizer now takes --use-composite-kclause-formulas-files flag,
which tells klocalizer to interpret the kclause formulas file in composite
format.

scripts/kclause_to_composite.py can be used to convert kclause files into
composite kclause files. The functionality of this script can be later
embedded into the formula extractor/generator to have this seamless.

(Edited)