### PR TITLE
Change choice handling to consider both depends on and visibility constraint

### DIFF
--- a/kextractors/kextractor-next-20200430/kextractor.c
+++ b/kextractors/kextractor-next-20200430/kextractor.c
@@ -1212,18 +1212,18 @@ int main(int argc, char **argv)
           if ((NULL != prop)) {
 
 	    if (printed_expr) {
-        fprintf(stderr, "warning: encountered multiple prompts, ignoring.");
-        break;
-        // commented code below can handle the case where multiple
+	      fprintf(stderr, "warning: encountered multiple prompts, ignoring.");
+	      break;
+	      // commented code below can handle the case where multiple
 	      // prompts are defined, where satisfying any of them makes
 	      // the config option visible. However, multiple prompts 
-        // raises a warning by Kconfig and we consider it as an 
-        // invalid use of Kconfig language. Thus, this code is 
-        // commented for now. Note that, using this code here
-        // means the code for prompt keyword should also reflect
-        // this case.
+	      // raises a warning by Kconfig and we consider it as an 
+	      // invalid use of Kconfig language. Thus, this code is 
+              // commented for now. Note that, using this code here
+              // means the code for prompt keyword should also reflect
+              // this case.
 	      //fprintf(output_fp, " or ");
-      }
+	    }
 	    
 	    printed_expr = 1;
 	    fprintf(output_fp, "(");

--- a/kextractors/kextractor-next-20200430/kextractor.c
+++ b/kextractors/kextractor-next-20200430/kextractor.c
@@ -1205,33 +1205,74 @@ int main(int argc, char **argv)
         // In conclusion, I (Necip) cannot deduce what leads to those different behaviours looking at the specific examples.
         // To understand, we need to have a deeper analysis on how Kconfig parser processes choice symbols.
         // Until then, let's have the conjunction of all to ensure we have valid (yet more in complex/repetitive form than needed) results.
-
-        // visible
-        if (prop->visible.expr) {
-          if (printed_expr) fprintf(output_fp, " and ");
-          printed_expr = 1;
-          fprintf(output_fp, "(");
-          print_python_expr(prop->visible.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
+	
+	// Both depends on and visibility shoul be satisfied for 
+	// the choice to be selectable.
+	// Kconfig conjuncts depends on constraint to the 
+	// visibility constraint, so that for choice, looking at
+	// only the visibility is sufficient.
+	// rev_dep of choice copies the visibility to prevent
+	// non-optional choices have no selection (menu.c, l854) 
+	// Thus, rev_dep is the same as visibiltiy except conjoing
+	// 'm' which is currently not needed for kclause.
+	// In sum, only visibility is needed as the condition of
+	// choice.
+        
+	prop = NULL;
+        for_all_prompts(sym, prop) {
+          if ((NULL != prop)) {
+	    // commented code below can handle the case where multiple
+	    // prompts are defined, where satisfying any of them makes
+	    // the config option visible. However, multiple prompts 
+	    // raises a warning by Kconfig and we consider it as an 
+	    // invalid use of Kconfig language. Thus, this code is 
+	    // commented for now. Note that, using this code here
+	    // means the code for prompt keyword should also reflect
+	    // this case.
+	    //if (printed_expr)
+	    //  fprintf(output_fp, " or ");
+	    
+	    printed_expr = 1;
+	    fprintf(output_fp, "(");
+            if (NULL != prop->visible.expr) {
+              print_python_expr(prop->visible.expr, output_fp, E_NONE);
+            } else {
+              fprintf(output_fp, "1");
+            }
+            fprintf(output_fp, ")");
+          }
         }
+ 
+	// below code for visible is not correct as the prop came
+	// from sym_get_choice_prop, which returns the choice values
+	// that this choice has.
+	
+	// visible
+        //if (prop->visible.expr) {
+        //  if (printed_expr) fprintf(output_fp, " and ");
+        //  printed_expr = 1;
+        //  fprintf(output_fp, "(");
+        //  print_python_expr(prop->visible.expr, output_fp, E_NONE);
+        //  fprintf(output_fp, ")");
+        //}
 
         // direct dependency
-        if (sym->dir_dep.expr) {
-          if (printed_expr) fprintf(output_fp, " and ");
-          printed_expr = 1;
-          fprintf(output_fp, "(");
-          print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
-        }
+        //if (sym->dir_dep.expr) {
+        //  if (printed_expr) fprintf(output_fp, " and ");
+        //  printed_expr = 1;
+        //  fprintf(output_fp, "(");
+        //  print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
+        //  fprintf(output_fp, ")");
+        //}
 
         // reverse dependency
-        if (sym->rev_dep.expr) {
-          if (printed_expr) fprintf(output_fp, " and ");
-          printed_expr = 1;
-          fprintf(output_fp, "(");
-          print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
-        }
+        //if (sym->rev_dep.expr) {
+        //  if (printed_expr) fprintf(output_fp, " and ");
+        //  printed_expr = 1;
+        //  fprintf(output_fp, "(");
+        //  print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
+        //  fprintf(output_fp, ")");
+        //}
 
         if (!printed_expr)
           fprintf(output_fp, "1");

--- a/kextractors/kextractor-next-20200430/kextractor.c
+++ b/kextractors/kextractor-next-20200430/kextractor.c
@@ -1193,19 +1193,6 @@ int main(int argc, char **argv)
         }
         fprintf(output_fp, "|(");
 
-        // for formatting
-        int printed_expr = 0;
-
-        // TODO: issue with the visible_expr, dir_dep.expr, and rev_dep.expr of choices
-        // The content of visible, direct dependency, and reverse dependency expressions are strange for choices:
-        // Seems like direct dependency expression is always NULL.
-        // visib_expr == NULL && rev_dep_expr != NULL -> rev_dep_expr == 1
-        // visib_expr != NULL && rev_dep_expr == NULL -> valid constraint in visib_expr. Example: check for CONFIG_USB_ZERO.
-        // visib_expr != NULL && rev_dep_expr != NULL -> they are the same most of the time except a few cases. Example: check for CONFIG_VMSPLIT_3G.
-        // In conclusion, I (Necip) cannot deduce what leads to those different behaviours looking at the specific examples.
-        // To understand, we need to have a deeper analysis on how Kconfig parser processes choice symbols.
-        // Until then, let's have the conjunction of all to ensure we have valid (yet more in complex/repetitive form than needed) results.
-	
 	// Both depends on and visibility shoul be satisfied for 
 	// the choice to be selectable.
 	// Kconfig conjuncts depends on constraint to the 
@@ -1217,20 +1204,26 @@ int main(int argc, char **argv)
 	// 'm' which is currently not needed for kclause.
 	// In sum, only visibility is needed as the condition of
 	// choice.
-        
+
+        // for formatting
+        int printed_expr = 0;
 	prop = NULL;
         for_all_prompts(sym, prop) {
           if ((NULL != prop)) {
-	    // commented code below can handle the case where multiple
-	    // prompts are defined, where satisfying any of them makes
-	    // the config option visible. However, multiple prompts 
-	    // raises a warning by Kconfig and we consider it as an 
-	    // invalid use of Kconfig language. Thus, this code is 
-	    // commented for now. Note that, using this code here
-	    // means the code for prompt keyword should also reflect
-	    // this case.
-	    //if (printed_expr)
-	    //  fprintf(output_fp, " or ");
+
+	    if (printed_expr) {
+        fprintf(stderr, "warning: encountered multiple prompts, ignoring.");
+        break;
+        // commented code below can handle the case where multiple
+	      // prompts are defined, where satisfying any of them makes
+	      // the config option visible. However, multiple prompts 
+        // raises a warning by Kconfig and we consider it as an 
+        // invalid use of Kconfig language. Thus, this code is 
+        // commented for now. Note that, using this code here
+        // means the code for prompt keyword should also reflect
+        // this case.
+	      //fprintf(output_fp, " or ");
+      }
 	    
 	    printed_expr = 1;
 	    fprintf(output_fp, "(");
@@ -1242,37 +1235,6 @@ int main(int argc, char **argv)
             fprintf(output_fp, ")");
           }
         }
- 
-	// below code for visible is not correct as the prop came
-	// from sym_get_choice_prop, which returns the choice values
-	// that this choice has.
-	
-	// visible
-        //if (prop->visible.expr) {
-        //  if (printed_expr) fprintf(output_fp, " and ");
-        //  printed_expr = 1;
-        //  fprintf(output_fp, "(");
-        //  print_python_expr(prop->visible.expr, output_fp, E_NONE);
-        //  fprintf(output_fp, ")");
-        //}
-
-        // direct dependency
-        //if (sym->dir_dep.expr) {
-        //  if (printed_expr) fprintf(output_fp, " and ");
-        //  printed_expr = 1;
-        //  fprintf(output_fp, "(");
-        //  print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
-        //  fprintf(output_fp, ")");
-        //}
-
-        // reverse dependency
-        //if (sym->rev_dep.expr) {
-        //  if (printed_expr) fprintf(output_fp, " and ");
-        //  printed_expr = 1;
-        //  fprintf(output_fp, "(");
-        //  print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
-        //  fprintf(output_fp, ")");
-        //}
 
         if (!printed_expr)
           fprintf(output_fp, "1");

--- a/kmax/kclause
+++ b/kmax/kclause
@@ -641,8 +641,14 @@ if __name__ == '__main__':
     for var in config_vars:
       defined_vars.add(var)
       possible_choices = possible_choices + delim + var
-      if var in dep_exprs and dep_exprs[var] != None:
-        individual_dep_expr = "(%s)" % (dep_exprs[var])
+
+      # for a choice value to be selectable, both its
+      # depends on and visibility constraints should be
+      # satisfied.  Since depends on constraint is 
+      # conjuncted to visibility constraint by Kconfig,
+      # indivitual_conditions use visibiltiy constrains
+      if var in prompt_lines and prompt_lines[var] != None:
+        individual_dep_expr = "(%s)" % (prompt_lines[var])
       else:
         individual_dep_expr = "(1)"
       individual_conditions = individual_conditions + delim + individual_dep_expr

--- a/kmax/kclause
+++ b/kmax/kclause
@@ -31,6 +31,7 @@ if __name__ == '__main__':
   import pickle
   import kmax.about
   import re
+  import itertools
 
   # this script takes the check_dep --dimacs output and converts it into
   # a dimacs-compatible format
@@ -607,11 +608,9 @@ if __name__ == '__main__':
     # TODO: Update choice_vars with tristate_choice as well when print_dimacs() method
     # is modified for tristate_choices.
     choice_vars.update(set(config_vars))
-    for i in range(0, len(config_vars)-1):
-      defined_vars.add(config_vars[i])
-      for j in range(i+1, len(config_vars)):
-        #if i != j:
-        add_clause(config_vars[i], z3.Or(z3.Not(z3.Bool(config_vars[i])), z3.Not(z3.Bool(config_vars[j]))))
+    defined_vars.update(set(config_vars))
+    for c1, c2 in itertools.combinations(config_vars, 2):
+      add_clause(c1, z3.Or(z3.Not(z3.Bool(c1)), z3.Not(z3.Bool(c2))))
     assert len(config_vars) > 0
     
   # TODO: generate mutex choice clauses for tristate choices
@@ -619,7 +618,7 @@ if __name__ == '__main__':
   # However, only one option can be set to "y". Since we cannot differentiate between "m" and "y"
   # with kclause, we cannot express the conditions for tristate choices in full. We can treat
   # them the same way we treat bool_choices, which would prevent setting multiple choices to "m".
-  # Or, we can just not consider the mutex "y" choice at all. Currently, we are doing the latter.
+  # Or, we can just not consider the mutex "y" choice at all. Currently, we are doing the former.
 
   # generate 'at least one' clause for boolean and tristate choices
   for (config_vars, dep_expr) in bool_choices + tristate_choices + bool_opt_choices + tristate_opt_choices:
@@ -639,14 +638,13 @@ if __name__ == '__main__':
     individual_conditions = ""
     delim = ""
     for var in config_vars:
-      defined_vars.add(var)
       possible_choices = possible_choices + delim + var
 
       # for a choice value to be selectable, both its
       # depends on and visibility constraints should be
       # satisfied.  Since depends on constraint is 
       # conjuncted to visibility constraint by Kconfig,
-      # indivitual_conditions use visibiltiy constrains
+      # individual_conditions use visibiltiy constrains
       if var in prompt_lines and prompt_lines[var] != None:
         individual_dep_expr = "(%s)" % (prompt_lines[var])
       else:

--- a/kmax/kclause
+++ b/kmax/kclause
@@ -607,11 +607,11 @@ if __name__ == '__main__':
     # TODO: Update choice_vars with tristate_choice as well when print_dimacs() method
     # is modified for tristate_choices.
     choice_vars.update(set(config_vars))
-    for i in range(0, len(config_vars)):
+    for i in range(0, len(config_vars)-1):
       defined_vars.add(config_vars[i])
-      for j in range(0, len(config_vars)):
-        if i != j:
-          add_clause(config_vars[i], z3.Or(z3.Not(z3.Bool(config_vars[i])), z3.Not(z3.Bool(config_vars[j]))))
+      for j in range(i+1, len(config_vars)):
+        #if i != j:
+        add_clause(config_vars[i], z3.Or(z3.Not(z3.Bool(config_vars[i])), z3.Not(z3.Bool(config_vars[j]))))
     assert len(config_vars) > 0
     
   # TODO: generate mutex choice clauses for tristate choices

--- a/tests/kclause_tests/emptyChoice
+++ b/tests/kclause_tests/emptyChoice
@@ -1,0 +1,32 @@
+config V
+	bool "V"
+
+config V1
+	bool "V1"
+
+config V2
+	bool "V2"
+
+config D
+	bool "D"
+
+config D1
+	bool "D1"
+
+config D2
+	bool "D2"
+
+
+choice 
+	bool "Choice" if V
+	depends on D
+
+	config C1
+		bool "C1" if V1
+		depends on D1 && D2
+	
+	config C2
+		bool "C2" if V2
+		depends on D2
+endchoice
+

--- a/tests/kclause_tests/emptyChoice.extract
+++ b/tests/kclause_tests/emptyChoice.extract
@@ -1,0 +1,19 @@
+config CONFIG_V2 bool
+prompt CONFIG_V2 (1)
+config CONFIG_C1 bool
+prompt CONFIG_C1 (1 and CONFIG_D1 and CONFIG_D2 and CONFIG_V1)
+config CONFIG_D2 bool
+prompt CONFIG_D2 (1)
+config CONFIG_D bool
+prompt CONFIG_D (1)
+config CONFIG_V1 bool
+prompt CONFIG_V1 (1)
+config CONFIG_C2 bool
+prompt CONFIG_C2 (1 and CONFIG_D2 and CONFIG_V2)
+config CONFIG_D1 bool
+prompt CONFIG_D1 (1)
+config CONFIG_V bool
+prompt CONFIG_V (1)
+bool_choice CONFIG_C1 CONFIG_C2|((CONFIG_D and CONFIG_V))
+dep CONFIG_C1 (1 and CONFIG_D1 and CONFIG_D2)
+dep CONFIG_C2 (1 and CONFIG_D2)

--- a/tests/kclause_tests/emptyChoice.pickle
+++ b/tests/kclause_tests/emptyChoice.pickle
@@ -1,0 +1,19 @@
+(dp0
+VCONFIG_C1
+p1
+(lp2
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_C2 () Bool)\u000a(declare-fun CONFIG_C1 () Bool)\u000a(assert\u000a (let (($x25 (not CONFIG_C2)))\u000a (let (($x23 (not CONFIG_C1)))\u000a (or $x23 $x25))))\u000a(check-sat)\u000a
+p3
+aV; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_C1 () Bool)\u000a(declare-fun CONFIG_V1 () Bool)\u000a(declare-fun CONFIG_D2 () Bool)\u000a(declare-fun CONFIG_D1 () Bool)\u000a(assert\u000a (let (($x57 (and CONFIG_D1 CONFIG_D2 CONFIG_V1 (or (not CONFIG_C1) (and CONFIG_D1 CONFIG_D2)))))\u000a (or $x57 (and (not (and CONFIG_D1 CONFIG_D2 CONFIG_V1)) (not CONFIG_C1)))))\u000a(check-sat)\u000a
+p4
+asV<CHOICE>
+p5
+(lp6
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_V2 () Bool)\u000a(declare-fun CONFIG_D2 () Bool)\u000a(declare-fun CONFIG_V1 () Bool)\u000a(declare-fun CONFIG_D1 () Bool)\u000a(declare-fun CONFIG_V () Bool)\u000a(declare-fun CONFIG_D () Bool)\u000a(declare-fun CONFIG_C2 () Bool)\u000a(declare-fun CONFIG_C1 () Bool)\u000a(assert\u000a (let (($x45 (and CONFIG_D2 CONFIG_V2)))\u000a (let (($x47 (and CONFIG_D CONFIG_V (or (and CONFIG_D1 CONFIG_D2 CONFIG_V1) $x45))))\u000a (let (($x50 (or (not (or CONFIG_C1 CONFIG_C2)) $x47)))\u000a (let (($x49 (or CONFIG_C1 CONFIG_C2 (not $x47))))\u000a (and $x49 $x50))))))\u000a(check-sat)\u000a
+p7
+asVCONFIG_C2
+p8
+(lp9
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_C2 () Bool)\u000a(declare-fun CONFIG_V2 () Bool)\u000a(declare-fun CONFIG_D2 () Bool)\u000a(assert\u000a (or (and CONFIG_D2 CONFIG_V2 (or (not CONFIG_C2) CONFIG_D2)) (and (not (and CONFIG_D2 CONFIG_V2)) (not CONFIG_C2))))\u000a(check-sat)\u000a
+p10
+as.


### PR DESCRIPTION
Choice and choice values are selectable only when both their depends on and visibility constraints are satisfied.
Regarding this, the following changes are made:
- Condition for choice now uses correct visibility condition and does not use dir_dep and rev_dep.
- Kclause uses visibility of choice values (which has depends on constraint conjuncted by kconfig) to generate choice clauses.

In addition, there is a small optimization to avoid generating redundant clauses for the choice mutex.