### PR TITLE
klocalizer: add --force-unmet-free and --allow-unmet-for options

### DIFF
--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -60,6 +60,131 @@ def get_kclause_constraints(kclause_file, is_file_composite):
 
     return constraints
 
+# z3 vector's size is assumed to be 0 or 1
+# helper to get_unmet_free_constraints() for reading dir_dep file
+def flatten_z3_vector(z3_vector):
+  if len(z3_vector) == 0:
+    return z3.BoolVal("True")
+  elif len(z3_vector) == 1:
+    return z3_vector[0]
+  else:
+    assert len(z3_vector) <= 1
+
+def get_unmet_free_constraints(kclause_dir_dep_file, except_for):
+  assert os.path.exists(kclause_dir_dep_file)
+  
+  with open(kclause_dir_dep_file, "rb") as f:
+	  dir_deps = pickle.load(f)
+
+  except_for = set(except_for)
+  consumed_except_for = set()
+
+  # compile the constraints
+  # to avoid unmet direct dependency for a symbol C, (C -> dir_dep_C) must hold true
+  implication = lambda x, y: z3.Or(z3.Not(x), y)
+  
+  constraints = []
+  for var in dir_deps:
+    if var in except_for:
+      consumed_except_for.add(var)
+      continue
+
+    c = implication(z3.Bool(var), flatten_z3_vector(z3.parse_smt2_string(dir_deps[var])))
+    constraints.append(c)
+  
+  # warn for the unconsumed except_for symbols
+  unconsumed_except_for = except_for.difference(consumed_except_for)
+  for var in sorted(list(unconsumed_except_for)):
+    warning("couldn't find the symbol '%s' for which to allow unmet direct dependency." % var)
+
+  return constraints
+
+def generate_kextract_file(formulas, arch):
+  kextract_file = get_arch_kextract_file(formulas, arch)
+  assert not os.path.exists(kextract_file)
+  os.makedirs(os.path.dirname(kextract_file), exist_ok=True)
+
+  # write to a temp file first, then move if successful
+  kextract_file_pending = kextract_file + ".pending"
+  command = [ "kextractlinux", arch, kextract_file_pending ]
+  info("Extracting Kconfig dependencies: %s" % (" ".join(command)))
+  try:
+    popen = subprocess.Popen(command)
+    popen.communicate()
+    if popen.returncode != 0:
+      error("Error running kextract: return code %d" % (popen.returncode))
+      exit(13)
+  except Exception as e:
+    error("Error running kextract: %s" % (str(e)))
+    exit(13)
+  os.rename(kextract_file_pending, kextract_file)
+
+  return os.path.exists(kextract_file)
+
+def generate_kclause_formulas(formulas, arch):
+  kclause_file = get_arch_kclause_file(formulas, arch)
+  assert not os.path.exists(kclause_file)
+  os.makedirs(os.path.dirname(kclause_file), exist_ok=True)
+
+  # write to a temp file first, then move if successful
+  kclause_file_pending = kclause_file + ".pending"
+
+  # todo, write stderr to log
+  info("Generating kclause formulas for %s." % (arch))
+
+  kextract_file = get_arch_kextract_file(formulas, arch)
+  if not os.path.exists(kextract_file):
+    generate_kextract_file(formulas, arch)
+  
+  assert os.path.exists(kextract_file)
+
+  # run kclause
+  with open(kclause_file_pending, 'w') as kclause_outf:
+    with open(kextract_file, 'r') as extract_inf:
+      command = ["kclause", "--remove-orphaned-nonvisible" ]
+      if quiet: command.append("--quiet")
+      info("Running kclause: %s < %s > %s" % (" ".join(command), extract_inf.name, kclause_outf.name))
+      info("This will take several minutes...")
+      popen = subprocess.Popen(command, stdin=extract_inf, stdout=kclause_outf) #, stderr=DEVNULL)
+      popen.communicate()
+      kclause_outf.flush()
+  os.rename(kclause_file_pending, kclause_file)
+
+  return os.path.exists(kclause_file)
+
+# generate kclause.normal_dep file, which has the {symbol : direct dependency} mapping
+def generate_kclause_dir_dep_file(formulas, arch):
+  kclause_dir_dep_file = get_arch_kclause_dir_dep_file(formulas, arch)
+  assert not os.path.exists(kclause_dir_dep_file)
+  os.makedirs(os.path.dirname(kclause_dir_dep_file), exist_ok=True)
+
+  # write to a temp file first, then move if successful
+  kclause_dir_dep_file_pending = kclause_dir_dep_file + ".pending"
+
+  # todo, write stderr to log
+  info("Generating kclause direct dependency formulas for %s." % (arch))
+
+  kextract_file = get_arch_kextract_file(formulas, arch)
+  if not os.path.exists(kextract_file):
+    generate_kextract_file(formulas, arch)
+  
+  assert os.path.exists(kextract_file)
+
+  # run kclause
+  with open(kclause_dir_dep_file_pending, 'w') as kclause_outf:
+    with open(kextract_file, 'r') as extract_inf:
+      #  kclause --normal-dependencies-only < $kextract_path > .kmax/kclause/${arch}/kclause.normal_dep 2>"$LOGS_DIR/kclause_create_normal_dep_${arch}.out"
+      command = ["kclause", "--normal-dependencies-only" ]
+      if quiet: command.append("--quiet")
+      info("Running kclause: %s < %s > %s" % (" ".join(command), extract_inf.name, kclause_outf.name))
+      info("This will take several minutes...")
+      popen = subprocess.Popen(command, stdin=extract_inf, stdout=kclause_outf) #, stderr=DEVNULL)
+      popen.communicate()
+      kclause_outf.flush()
+  os.rename(kclause_dir_dep_file_pending, kclause_dir_dep_file)
+
+  return os.path.exists(kclause_dir_dep_file)
+
 def get_resolved_to_kbuild_map(kmax):
   # resolve all kbuild paths to file names, remove ../ relative
   # paths.  these paths are needed in the kmax formulas to preserve
@@ -308,6 +433,9 @@ def get_arch_kclause_subdir(formulas, arch):
 def get_arch_kclause_file(formulas, arch):
   return os.path.join(get_arch_kclause_subdir(formulas, arch), "kclause")
 
+def get_arch_kclause_dir_dep_file(formulas, arch):
+  return os.path.join(get_arch_kclause_subdir(formulas, arch), "kclause.normal_dep")
+
 def get_arch_kextract_file(formulas, arch):
   return os.path.join(get_arch_kclause_subdir(formulas, arch), "kextract")
 
@@ -435,6 +563,14 @@ if __name__ == '__main__':
   argparser.add_argument("--exclude-compilation-units",
                          action="store_true",
                          help="""Invert the z3 formula of the compilation unit (.o file) when generating .config""")
+  argparser.add_argument("--force-unmet-free",
+                         action="store_true",
+                         help="""Force unmet direct dependency free configuration.  This requires kclause direct depedency formulas file to exist in KMAX_FORMULAS/kclause/ARCH/kclause.normal_dep, which is a pickled dictionary from configuration options to direct dependency formulas.""")
+  argparser.add_argument("--allow-unmet-for",
+                         action="append",
+                         nargs="*",
+                         default=[],
+                         help="""The list of configuration symbols for which allow unmet direct dependency.  Can be used with --force-unmet-free only to relax the constraints for some symbols.""")
   argparser.add_argument('-q',
                          '--quiet',
                          action="store_true",
@@ -472,7 +608,12 @@ if __name__ == '__main__':
   random_seed = args.random_seed
   compilation_units = args.compilation_units
   dont_compile = args.exclude_compilation_units
+  force_unmet_free = args.force_unmet_free
+  allow_unmet_for = args.allow_unmet_for
   quiet = args.quiet
+
+  # flatten allow_unmet_for list of lists
+  allow_unmet_for = [ item for elem in allow_unmet_for for item in elem ]
 
   if kextract_file and not kclause_file:
     argparser.print_help()
@@ -489,6 +630,11 @@ if __name__ == '__main__':
     error("Cannot use --report-all when providing an explicit --kclause-formulas argument.")
     exit(12)
   
+  if allow_unmet_for and not force_unmet_free:
+    argparser.print_help()
+    error("--allow-unmet-for can only be used with --force-unmet-free.")
+    exit(12)
+
   if sample is not None:
     if sample_prefix is None:
       sample_prefix="config"
@@ -673,161 +819,146 @@ if __name__ == '__main__':
     if arch is not None:
       info("Trying \"%s\"" % (arch))
     info("Kclause formulas file: %s" % (kclause_file))
+
+    # check kclause formulas file
     if not os.path.exists(kclause_file):
-      kclause_file_pending = kclause_file + ".pending"
-      if not os.path.exists(os.path.dirname(kclause_file)):
-        os.makedirs(os.path.dirname(kclause_file))
-      # todo, write stderr to log
-      info("Generating kclause formulas for %s." % (arch))
-      if not os.path.exists(get_arch_kextract_file(formulas, arch)):
-        # write to a temp file first, then move if successful
-        kextract_file_pending = get_arch_kextract_file(formulas, arch) + ".pending"
-        command = [ "kextractlinux", arch, kextract_file_pending ]
-        info("Extracting Kconfig dependencies: %s" % (" ".join(command)))
-        try:
-          popen = subprocess.Popen(command)
-          popen.communicate()
-          if popen.returncode != 0:
-            error("Error running kextract: return code %d" % (popen.returncode))
-            exit(13)
-        except Exception as e:
-          error("Error running kextract: %s" % (str(e)))
-          exit(13)
-        os.rename(kextract_file_pending, get_arch_kextract_file(formulas, arch))
-      # run kclause
-      with open(kclause_file_pending, 'w') as kclause_outf:
-        with open(get_arch_kextract_file(formulas, arch), 'r') as extract_inf:
-          command = ["kclause", "--remove-orphaned-nonvisible" ]
-          if quiet: command.append("--quiet")
-          info("Running kclause: %s < %s > %s" % (" ".join(command), extract_inf.name, kclause_outf.name))
-          info("This will take several minutes...")
-          popen = subprocess.Popen(command, stdin=extract_inf, stdout=kclause_outf) #, stderr=DEVNULL)
-          popen.communicate()
-          kclause_outf.flush()
-      os.rename(kclause_file_pending, kclause_file)
+      generate_kclause_formulas(formulas, arch)
     if not os.path.exists(kclause_file):
       error("Cannot find kclause formulas file: %s" % (kclause_file))
+    
+    # check kclause direct dependency file, if needed
+    kclause_dir_dep_file = get_arch_kclause_dir_dep_file(formulas, arch)
+    if force_unmet_free:
+      info("Kclause direct dependency formulas file: %s" % kclause_dir_dep_file)
+      if not os.path.exists(kclause_dir_dep_file):
+        generate_kclause_dir_dep_file(formulas, arch)
+      if not os.path.exists(kclause_dir_dep_file):
+        error("Cannot find kclause direct dependency file needed for --force-unmet-free: %s)" % (kclause_dir_dep_file))
+
+    constraints = []
+
+    if arch is not None:
+      kextract = get_kextract(get_arch_kextract_file(formulas, arch))
+    elif kextract_file is not None:
+      kextract = kextract_file
     else:
-      constraints = []
-
-      if arch is not None:
-        kextract = get_kextract(get_arch_kextract_file(formulas, arch))
-      elif kextract_file is not None:
-        kextract = kextract_file
-      else:
-        kextract = None
-        
-      if kextract == None:
-        info("No kextract file available.  Assuming all configuration options are Boolean")
-        kconfig_types = None
-        kconfig_visible = None
-        kconfig_has_def_nonbool = None
-      else:
-        kconfig_types = {}
-        kconfig_visible = set()
-        kconfig_has_def_nonbool = set()
-        for kconfig_line in kextract:
-          # see docs/kextract_format.md for more info
-          if kconfig_line[0] == "config":
-            kconfig_types[kconfig_line[1]] = kconfig_line[2]
-          if kconfig_line[0] == "prompt":
-            kconfig_visible.add(kconfig_line[1])
-          if kconfig_line[0] == "def_nonbool":
-            kconfig_has_def_nonbool.add(kconfig_line[1])
-        if allow_non_visibles:
-          kconfig_visible = None
-
-      if kmax_constraints:
-        # add the kmax constraints
-        constraints.extend(kmax_constraints)
-        # disable any Boolean configuration options not defined in this architecture
-        if kconfig_types:
-          for kmax_constraint in kmax_constraints:
-            used_vars = z3.z3util.get_vars(kmax_constraint)
-            vars_not_in_arch = [ used_var for used_var in used_vars if str(used_var) not in kconfig_types.keys() and token_pattern.match(str(used_var)) ]
-            for used_var in vars_not_in_arch:
-              constraints.append(z3.Not(used_var))
-
-      user_specified_option_names = set()
-              
-      if constraints_file:
-        ad_hoc_constraints, ad_hoc_config_options = get_ad_hoc_constraints(constraints_file)
-        constraints.extend(ad_hoc_constraints)
-        user_specified_option_names.update(ad_hoc_config_options)
-
-      if constraints_file_smt2:
-        with open(constraints_file_smt2, "r") as f:
-          constraints.extend( z3.parse_smt2_string(f.read()) )
-
-      # add kclause constraints
-      constraints.extend(get_kclause_constraints(kclause_file, use_composite_kclause_formulas_files))
-
-      user_constraints = []
+      kextract = None
       
-      # add user-specified constraints
-      for user_define in define:
-        user_constraint = z3.Bool(user_define)
-        constraints.append(user_constraint)
-        user_specified_option_names.add(user_define)
-        user_constraints.append(user_constraint)
-      for user_undefine in undefine:
-        user_constraint = z3.Not(z3.Bool(user_undefine))
-        constraints.append(user_constraint)
-        user_specified_option_names.add(user_undefine)
-        user_constraints.append(user_constraint)
+    if kextract == None:
+      info("No kextract file available.  Assuming all configuration options are Boolean")
+      kconfig_types = None
+      kconfig_visible = None
+      kconfig_has_def_nonbool = None
+    else:
+      kconfig_types = {}
+      kconfig_visible = set()
+      kconfig_has_def_nonbool = set()
+      for kconfig_line in kextract:
+        # see docs/kextract_format.md for more info
+        if kconfig_line[0] == "config":
+          kconfig_types[kconfig_line[1]] = kconfig_line[2]
+        if kconfig_line[0] == "prompt":
+          kconfig_visible.add(kconfig_line[1])
+        if kconfig_line[0] == "def_nonbool":
+          kconfig_has_def_nonbool.add(kconfig_line[1])
+      if allow_non_visibles:
+        kconfig_visible = None
 
-      if arch is not None:
-        constraints.extend(get_arch_specific_constraints(arch, architecture_configs))
+    if kmax_constraints:
+      # add the kmax constraints
+      constraints.extend(kmax_constraints)
+      # disable any Boolean configuration options not defined in this architecture
+      if kconfig_types:
+        for kmax_constraint in kmax_constraints:
+          used_vars = z3.z3util.get_vars(kmax_constraint)
+          vars_not_in_arch = [ used_var for used_var in used_vars if str(used_var) not in kconfig_types.keys() and token_pattern.match(str(used_var)) ]
+          for used_var in vars_not_in_arch:
+            constraints.append(z3.Not(used_var))
 
-      if disable_config_broken: constraints.append(config_broken)
+    user_specified_option_names = set()
+            
+    if constraints_file:
+      ad_hoc_constraints, ad_hoc_config_options = get_ad_hoc_constraints(constraints_file)
+      constraints.extend(ad_hoc_constraints)
+      user_specified_option_names.update(ad_hoc_config_options)
 
-      solver = z3.Solver()
-      solver.set(unsat_core=True)
-      if random_seed is not None:
-        solver.set(random_seed=random_seed)
+    if constraints_file_smt2:
+      with open(constraints_file_smt2, "r") as f:
+        constraints.extend( z3.parse_smt2_string(f.read()) )
 
-      if (solver.check(constraints) == z3.unsat):
-        info("The constraints are unsatisfiable.  Either no configuration is possible or the formulas are overconstrained.")
-        if show_unsat_core:
-          info("The following constraint(s) prevented satisfiability:\n%s" % (str(solver.unsat_core())))
-        else:
-          if not seen_unsat:
-            info("Run with --show-unsat-core to see what constraints prevented satisfiability.")
-            seen_unsat = True
-        if disable_config_broken and config_broken in solver.unsat_core():
-          error("Found a dependency on CONFIG_BROKEN, so the compilation unit may not be buildable.  Stopping the search.  Run again with --allow-config-broken to search anyway.")
-          exit(10)
+    # add kclause constraints
+    constraints.extend(get_kclause_constraints(kclause_file, use_composite_kclause_formulas_files))
+
+    # add unmet direct dependency free constraints, if needed
+    if force_unmet_free:
+      constraints.extend(get_unmet_free_constraints( kclause_dir_dep_file, allow_unmet_for))
+
+    user_constraints = []
+    
+    # add user-specified constraints
+    for user_define in define:
+      user_constraint = z3.Bool(user_define)
+      constraints.append(user_constraint)
+      user_specified_option_names.add(user_define)
+      user_constraints.append(user_constraint)
+    for user_undefine in undefine:
+      user_constraint = z3.Not(z3.Bool(user_undefine))
+      constraints.append(user_constraint)
+      user_specified_option_names.add(user_undefine)
+      user_constraints.append(user_constraint)
+
+    if arch is not None:
+      constraints.extend(get_arch_specific_constraints(arch, architecture_configs))
+
+    if disable_config_broken: constraints.append(config_broken)
+
+    solver = z3.Solver()
+    solver.set(unsat_core=True)
+    if random_seed is not None:
+      solver.set(random_seed=random_seed)
+
+    if (solver.check(constraints) == z3.unsat):
+      info("The constraints are unsatisfiable.  Either no configuration is possible or the formulas are overconstrained.")
+      if show_unsat_core:
+        info("The following constraint(s) prevented satisfiability:\n%s" % (str(solver.unsat_core())))
       else:
-        info("The constraints are satisfiable.")
-        sat_archs.append(arch)
-        if not reportallarchs:
-          if not sample:
-            model = solver.model()
-            if approximate:
-              model = approximate_model(approximate, constraints, user_constraints)
-            if model is not None:
-              info("Writing the configuration to %s" % (output_file))
-              with open(output_file, 'w') as config_fp:
-                print_model_as_config(model, config_fp, kconfig_types, kconfig_visible, kconfig_has_def_nonbool, user_specified_option_names, modules_arg)
-              if arch is not None:
-                info("Generated configuration for %s" % (arch))
-                if not compilation_units:
-                  # If no compilation unit was specified, build command is for building the whole kernel
-                  build_cmd = "make.cross ARCH=%s clean; make.cross ARCH=%s" % (arch, arch)
-                else:
-                  build_cmd = "make.cross ARCH=%s clean %s" % (arch, " ".join(compilation_units))
-                info("Build with \"make.cross ARCH=%s olddefconfig; %s\"." % (arch, build_cmd))
-                print(arch)
-              exit(0)
-          else:
-            info("Generating %s configurations with prefix %s" % (str(sample), sample_prefix))
-            for config_i in range(0, sample):
-              if config_i != 0:  # solver.check already called when checking sat above
-                solver.check(constraints)
-              config_filename = "%s%d" % (sample_prefix, config_i + 1)
-              with open(config_filename, 'w') as config_fp:
-                print_model_as_config(solver.model(), config_fp, kconfig_types, kconfig_visible, kconfig_has_def_nonbool, user_specified_option_names, modules_arg)
+        if not seen_unsat:
+          info("Run with --show-unsat-core to see what constraints prevented satisfiability.")
+          seen_unsat = True
+      if disable_config_broken and config_broken in solver.unsat_core():
+        error("Found a dependency on CONFIG_BROKEN, so the compilation unit may not be buildable.  Stopping the search.  Run again with --allow-config-broken to search anyway.")
+        exit(10)
+    else:
+      info("The constraints are satisfiable.")
+      sat_archs.append(arch)
+      if not reportallarchs:
+        if not sample:
+          model = solver.model()
+          if approximate:
+            model = approximate_model(approximate, constraints, user_constraints)
+          if model is not None:
+            info("Writing the configuration to %s" % (output_file))
+            with open(output_file, 'w') as config_fp:
+              print_model_as_config(model, config_fp, kconfig_types, kconfig_visible, kconfig_has_def_nonbool, user_specified_option_names, modules_arg)
+            if arch is not None:
+              info("Generated configuration for %s" % (arch))
+              if not compilation_units:
+                # If no compilation unit was specified, build command is for building the whole kernel
+                build_cmd = "make.cross ARCH=%s clean; make.cross ARCH=%s" % (arch, arch)
+              else:
+                build_cmd = "make.cross ARCH=%s clean %s" % (arch, " ".join(compilation_units))
+              info("Build with \"make.cross ARCH=%s olddefconfig; %s\"." % (arch, build_cmd))
+              print(arch)
             exit(0)
+        else:
+          info("Generating %s configurations with prefix %s" % (str(sample), sample_prefix))
+          for config_i in range(0, sample):
+            if config_i != 0:  # solver.check already called when checking sat above
+              solver.check(constraints)
+            config_filename = "%s%d" % (sample_prefix, config_i + 1)
+            with open(config_filename, 'w') as config_fp:
+              print_model_as_config(solver.model(), config_fp, kconfig_types, kconfig_visible, kconfig_has_def_nonbool, user_specified_option_names, modules_arg)
+          exit(0)
   if reportallarchs and len(sat_archs) > 0:
     print("\n".join(sat_archs))
     exit(0)

--- a/tests/klocalizer_tests/assets/unmetdd_constraints_for_GENERIC_PINCONF_by_PINCTRL_RT2880.smt2
+++ b/tests/klocalizer_tests/assets/unmetdd_constraints_for_GENERIC_PINCONF_by_PINCTRL_RT2880.smt2
@@ -1,0 +1,11 @@
+; benchmark generated from python API
+(set-info :status unknown)
+(declare-fun CONFIG_RALINK () Bool)
+(declare-fun CONFIG_STAGING () Bool)
+(declare-fun CONFIG_PINCTRL () Bool)
+(declare-fun CONFIG_PINCTRL_RT2880 () Bool)
+(assert
+ (let (($x39 (and CONFIG_STAGING CONFIG_RALINK)))
+ (let (($x13 (not CONFIG_PINCTRL)))
+ (and CONFIG_PINCTRL_RT2880 $x39 $x13 $x39))))
+(check-sat)

--- a/tests/klocalizer_tests/assets/unmetdd_constraints_for_GPIOLIB_IRQCHIP_by_PINCTRL_BCM2835.smt2
+++ b/tests/klocalizer_tests/assets/unmetdd_constraints_for_GPIOLIB_IRQCHIP_by_PINCTRL_BCM2835.smt2
@@ -1,0 +1,12 @@
+; benchmark generated from python API
+(set-info :status unknown)
+(declare-fun CONFIG_COMPILE_TEST () Bool)
+(declare-fun CONFIG_OF () Bool)
+(declare-fun CONFIG_PINCTRL () Bool)
+(declare-fun CONFIG_GPIOLIB () Bool)
+(declare-fun CONFIG_PINCTRL_BCM2835 () Bool)
+(assert
+ (let (($x21 (and CONFIG_PINCTRL CONFIG_OF CONFIG_COMPILE_TEST)))
+ (let (($x6 (not CONFIG_GPIOLIB)))
+ (and CONFIG_PINCTRL_BCM2835 $x21 $x6 $x21))))
+(check-sat)

--- a/tests/klocalizer_tests/assets/unmetdd_constraints_for_GRO_CELLS_by_MACSEC.smt2
+++ b/tests/klocalizer_tests/assets/unmetdd_constraints_for_GRO_CELLS_by_MACSEC.smt2
@@ -1,0 +1,11 @@
+; benchmark generated from python API
+(set-info :status unknown)
+(declare-fun CONFIG_NET_CORE () Bool)
+(declare-fun CONFIG_NETDEVICES () Bool)
+(declare-fun CONFIG_NET () Bool)
+(declare-fun CONFIG_MACSEC () Bool)
+(assert
+ (let (($x57 (and CONFIG_NETDEVICES CONFIG_NET_CORE)))
+ (let (($x55 (not CONFIG_NET)))
+ (and CONFIG_MACSEC $x57 $x55 $x57))))
+(check-sat)

--- a/tests/klocalizer_tests/testunmetfree.sh
+++ b/tests/klocalizer_tests/testunmetfree.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Test --for-unmet-free and --allow-unmet-for options for klocalizer
+
+# Input: kernel source
+if [[ "${#}" < "1" ]]; then
+  echo "USAGE: $(basename ${0}) KSRC"
+  echo "  KSRC         The path to the kernel source directory (tests are reproducible for v5.4.4)."
+  exit 1
+fi
+
+KSRC=$(realpath $1)
+
+# Test case paths
+inp1="assets/unmetdd_constraints_for_GPIOLIB_IRQCHIP_by_PINCTRL_BCM2835.smt2"
+inp2="assets/unmetdd_constraints_for_GRO_CELLS_by_MACSEC.smt2"
+
+inp1="$(realpath $(dirname $0)/$inp1)"
+inp2="$(realpath $(dirname $0)/$inp2)"
+
+# Check if the required folders/files exist
+if [ ! -d "$KSRC" ]; then
+  echo "The directory '${KSRC}' doesn't exist."
+  exit 1
+fi
+
+if [ ! -f "$inp1" ] || [ ! -f "$inp2" ]; then
+  echo "Cannot find some of the input files."
+  exit 1
+fi
+
+# From now on, we are on the kernel directory
+cd $KSRC
+make kernelversion > /dev/null 2>&1
+
+if [ ! "$?" -eq "0" ]; then
+  echo "The input directory does not look like a kernel source directory: `make kernelversion` failed!."
+  exit 1
+fi
+
+# Check the exit code ("$?") to see if the last operation was success or fail, and print the result.
+# Inputs: $1: Expected exit code
+check_success() {
+    exit_code=$?
+    expected=$1
+    if [ $expected -eq $exit_code ]; then
+        result="PASS"
+    else
+        result="FAIL (exit code: $exit_code, expected: $expected)"
+    fi
+
+    echo $result 1>&2
+    echo ""
+}
+
+# Test case 1: unmetdd_constraints_for_GPIOLIB_IRQCHIP_by_PINCTRL_BCM2835.smt2 (inp1)
+klocalizer -a=x86_64 --constraints-file-smt2=$inp1; check_success 0 # should pass
+klocalizer -a=x86_64 --constraints-file-smt2=$inp1 --force-unmet-free; check_success 11 # should fail
+klocalizer -a=x86_64 --constraints-file-smt2=$inp1 --force-unmet-free --allow-unmet-for CONFIG_GPIOLIB_IRQCHIP; check_success 0 # should pass
+
+# Test case 2: unmetdd_constraints_for_GRO_CELLS_by_MACSEC.smt2 (inp2)
+# This is a more complex test case. With the constraints file (inp2), we ask
+# klocalizer to localize a config in which GRO_CELLS is selected by MACSEC
+# but GRO_CELLS's dependency condition is not satisfied. When we use the
+# options "--force-unmet-free --allow-unmet-for CONFIG_GRO_CELLS", klocalizer
+# still fails because MACSEC depends on NETDEVICES and ETHERNET, which share
+# the same direct dependency (NET) with GRO_CELLS. Consequently, it is not
+# possible to create a unmet direct dependency issue with (GRO_CELLS, MACSEC)
+# with forcing NETDEVICES and ETHERNET to be unmet free. Therefore, when we
+# add those symbols to --allow-unmet-for list, the test passes, resulting in
+# multiple unmet direct dependency warnings.
+klocalizer -a=powerpc --constraints-file-smt2=$inp2; check_success 0 # should pass
+klocalizer -a=powerpc --constraints-file-smt2=$inp2 --force-unmet-free; check_success 11 # should fail
+klocalizer -a=powerpc --constraints-file-smt2=$inp2 --force-unmet-free --allow-unmet-for CONFIG_GRO_CELLS; check_success 11 # should fail
+klocalizer -a=powerpc --constraints-file-smt2=$inp2 --force-unmet-free --allow-unmet-for CONFIG_GRO_CELLS CONFIG_NETDEVICES CONFIG_ETHERNET; check_success 0 # should pass


### PR DESCRIPTION
Unmet direct dependency for a config C can be avoided by using
implication(C, dir_dep_C) constraint. Adding such constraint for all
symbols would force the output config to be unmet direct dependency free.
The new option --force-unmet-free achieves by creating another kclause
formulas file, i.e. kclause direct dependency formulas, and using this
to add such constraints.

With --allow-unmet-for, one can add exceptions to --force-unmet-free by
listing for which symbols to not add such constraint.

The newly added tests, i.e. tests/testunmetfree.sh, demonstrates and tests
the usage of the newly added options.

Finally, some refactoring is done in klocalizer for the sake of
readability.