### PR TITLE
Fixed unmet direct dependency to break the chain of selects

### DIFF
--- a/kmax/kclause
+++ b/kmax/kclause
@@ -705,7 +705,7 @@ if __name__ == '__main__':
       # VAR, VAR's rev_dep_expr will contain "SEL and DIR_DEP".  we can
       # remove the DIR_DEP for SEL, since it will be covered when
       # processing SEL.  this reduces clause size.
-      if rev_dep_expr != None and rev_dep_expr != "(1)":
+      if False and rev_dep_expr != None and rev_dep_expr != "(1)":
         # get all the top-level terms of this clause.  the reverse
         # dependency will be a union of "SEL and DIR_DEP" terms,
         # representing each of the reverse dependencies.

--- a/tests/kclause_tests/unmetChain1
+++ b/tests/kclause_tests/unmetChain1
@@ -1,0 +1,16 @@
+config S1
+	bool "S1"
+	select S2
+
+config S2
+	bool "S2"
+	select S3
+	depends on D
+
+config D
+	bool "D"
+
+config S3
+	bool
+	
+

--- a/tests/kclause_tests/unmetChain1.extract
+++ b/tests/kclause_tests/unmetChain1.extract
@@ -1,0 +1,12 @@
+config CONFIG_D bool
+prompt CONFIG_D (1)
+config CONFIG_S1 bool
+prompt CONFIG_S1 (1)
+config CONFIG_S2 bool
+prompt CONFIG_S2 (CONFIG_D)
+config CONFIG_S3 bool
+select CONFIG_S2 CONFIG_S1 (1)
+dep CONFIG_S2 (CONFIG_D)
+select CONFIG_S3 CONFIG_S2 (CONFIG_D)
+rev_dep CONFIG_S2 (CONFIG_S1)
+rev_dep CONFIG_S3 (CONFIG_S2 and CONFIG_D)

--- a/tests/kclause_tests/unmetChain1.pickle
+++ b/tests/kclause_tests/unmetChain1.pickle
@@ -1,0 +1,12 @@
+(dp0
+VCONFIG_S2
+p1
+(lp2
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_S2 () Bool)\u000a(declare-fun CONFIG_S1 () Bool)\u000a(declare-fun CONFIG_D () Bool)\u000a(assert\u000a (let (($x46 (and (not CONFIG_D) (or (not CONFIG_S2) CONFIG_S1) (or (not CONFIG_S1) CONFIG_S2))))\u000a (let (($x43 (and CONFIG_D (or CONFIG_S1 CONFIG_D (not CONFIG_S2)) (or (not CONFIG_S1) CONFIG_S2))))\u000a (or $x43 $x46))))\u000a(check-sat)\u000a
+p3
+asVCONFIG_S3
+p4
+(lp5
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_S3 () Bool)\u000a(declare-fun CONFIG_D () Bool)\u000a(declare-fun CONFIG_S2 () Bool)\u000a(assert\u000a (and (or (not CONFIG_S3) (and CONFIG_S2 CONFIG_D)) (or (not (and CONFIG_S2 CONFIG_D)) CONFIG_S3)))\u000a(check-sat)\u000a
+p6
+as.

--- a/tests/kclause_tests/unmetChain2
+++ b/tests/kclause_tests/unmetChain2
@@ -1,0 +1,16 @@
+config S1
+	bool "S1"
+	select S2
+
+config S2
+	bool "S2"
+	select S3
+	depends on D
+
+config D
+	bool
+
+config S3
+	bool
+	
+

--- a/tests/kclause_tests/unmetChain2.extract
+++ b/tests/kclause_tests/unmetChain2.extract
@@ -1,0 +1,11 @@
+config CONFIG_D bool
+config CONFIG_S1 bool
+prompt CONFIG_S1 (1)
+config CONFIG_S2 bool
+prompt CONFIG_S2 (CONFIG_D)
+config CONFIG_S3 bool
+select CONFIG_S2 CONFIG_S1 (1)
+dep CONFIG_S2 (CONFIG_D)
+select CONFIG_S3 CONFIG_S2 (CONFIG_D)
+rev_dep CONFIG_S2 (CONFIG_S1)
+rev_dep CONFIG_S3 (CONFIG_S2 and CONFIG_D)

--- a/tests/kclause_tests/unmetChain2.pickle
+++ b/tests/kclause_tests/unmetChain2.pickle
@@ -1,0 +1,12 @@
+(dp0
+VCONFIG_S3
+p1
+(lp2
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_S3 () Bool)\u000a(declare-fun CONFIG_D () Bool)\u000a(declare-fun CONFIG_S2 () Bool)\u000a(assert\u000a (and (or (not CONFIG_S3) (and CONFIG_S2 CONFIG_D)) (or (not (and CONFIG_S2 CONFIG_D)) CONFIG_S3)))\u000a(check-sat)\u000a
+p3
+asVCONFIG_S2
+p4
+(lp5
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_S2 () Bool)\u000a(declare-fun CONFIG_S1 () Bool)\u000a(declare-fun CONFIG_D () Bool)\u000a(assert\u000a (let (($x53 (and (not CONFIG_D) (or (not CONFIG_S2) CONFIG_S1) (or (not CONFIG_S1) CONFIG_S2))))\u000a (let (($x50 (and CONFIG_D (or CONFIG_S1 CONFIG_D (not CONFIG_S2)) (or (not CONFIG_S1) CONFIG_S2))))\u000a (or $x50 $x53))))\u000a(check-sat)\u000a
+p6
+as.

--- a/tests/kclause_tests/unmetChain3
+++ b/tests/kclause_tests/unmetChain3
@@ -1,0 +1,16 @@
+config S1
+	bool "S1"
+	select S2
+
+config S2
+	bool
+	select S3
+	depends on D
+
+config D
+	bool
+
+config S3
+	bool
+	
+

--- a/tests/kclause_tests/unmetChain3.extract
+++ b/tests/kclause_tests/unmetChain3.extract
@@ -1,0 +1,10 @@
+config CONFIG_D bool
+config CONFIG_S1 bool
+prompt CONFIG_S1 (1)
+config CONFIG_S2 bool
+config CONFIG_S3 bool
+select CONFIG_S2 CONFIG_S1 (1)
+dep CONFIG_S2 (CONFIG_D)
+select CONFIG_S3 CONFIG_S2 (CONFIG_D)
+rev_dep CONFIG_S2 (CONFIG_S1)
+rev_dep CONFIG_S3 (CONFIG_S2 and CONFIG_D)

--- a/tests/kclause_tests/unmetChain3.pickle
+++ b/tests/kclause_tests/unmetChain3.pickle
@@ -1,0 +1,12 @@
+(dp0
+VCONFIG_S2
+p1
+(lp2
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_S2 () Bool)\u000a(declare-fun CONFIG_S1 () Bool)\u000a(assert\u000a (and (or (not CONFIG_S2) CONFIG_S1) (or (not CONFIG_S1) CONFIG_S2)))\u000a(check-sat)\u000a
+p3
+asVCONFIG_S3
+p4
+(lp5
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_S3 () Bool)\u000a(declare-fun CONFIG_D () Bool)\u000a(declare-fun CONFIG_S2 () Bool)\u000a(assert\u000a (and (or (not CONFIG_S3) (and CONFIG_S2 CONFIG_D)) (or (not (and CONFIG_S2 CONFIG_D)) CONFIG_S3)))\u000a(check-sat)\u000a
+p6
+as.

--- a/tests/kclause_tests/unmetChain4
+++ b/tests/kclause_tests/unmetChain4
@@ -1,0 +1,16 @@
+config S1
+	bool "S1"
+	select S2
+
+config S2
+	bool
+	select S3
+	depends on D
+
+config D
+	bool "D"
+
+config S3
+	bool
+	
+

--- a/tests/kclause_tests/unmetChain4.extract
+++ b/tests/kclause_tests/unmetChain4.extract
@@ -1,0 +1,11 @@
+config CONFIG_D bool
+prompt CONFIG_D (1)
+config CONFIG_S1 bool
+prompt CONFIG_S1 (1)
+config CONFIG_S2 bool
+config CONFIG_S3 bool
+select CONFIG_S2 CONFIG_S1 (1)
+dep CONFIG_S2 (CONFIG_D)
+select CONFIG_S3 CONFIG_S2 (CONFIG_D)
+rev_dep CONFIG_S2 (CONFIG_S1)
+rev_dep CONFIG_S3 (CONFIG_S2 and CONFIG_D)

--- a/tests/kclause_tests/unmetChain4.pickle
+++ b/tests/kclause_tests/unmetChain4.pickle
@@ -1,0 +1,12 @@
+(dp0
+VCONFIG_S3
+p1
+(lp2
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_S3 () Bool)\u000a(declare-fun CONFIG_D () Bool)\u000a(declare-fun CONFIG_S2 () Bool)\u000a(assert\u000a (and (or (not CONFIG_S3) (and CONFIG_S2 CONFIG_D)) (or (not (and CONFIG_S2 CONFIG_D)) CONFIG_S3)))\u000a(check-sat)\u000a
+p3
+asVCONFIG_S2
+p4
+(lp5
+V; benchmark generated from python API\u000a(set-info :status unknown)\u000a(declare-fun CONFIG_S2 () Bool)\u000a(declare-fun CONFIG_S1 () Bool)\u000a(assert\u000a (and (or (not CONFIG_S2) CONFIG_S1) (or (not CONFIG_S1) CONFIG_S2)))\u000a(check-sat)\u000a
+p6
+as.


### PR DESCRIPTION
Unmet dependency may break the chain of select statements over config options, 
as select statement of a config options is in effect only when the option's depends on 
constraint is met, regardless of whether the option is being selected by other option's
select constraints.

Kextract handles this correctly by conjoining the conditions of select and depends on,
but kclause was removing the condition from depends on to reduce the length of the
formula.  This is disabled for the correct behavior of select.