### PR TITLE
Automatically d/l cached formulas; version-specific .kmax folders

### DIFF
--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -3,7 +3,6 @@
 from kmax.klocalizer import *
 import logging
 
-
 class BasicLogger:
   def __init__(self, quiet=False):
     self.quiet = quiet
@@ -55,6 +54,10 @@ def klocalizerCLI():
   argparser.add_argument('--constraints-file-smt2',
                          type=str,
                          help="""A text file containing constraints in SMTLib format.""")
+  argparser.add_argument('-c',
+                         '--cached-formula-download',
+                         action="store_true",
+                         help="""Check configtools.org for a cached copy of this Linux version's kclause formulas to the local cache .kmax/.  Requires a git clone of Linux to discover version via tag.  Warning: this will overwrite the .kmax/ cache directory.""")
   argparser.add_argument('-a',
                          '--arch',
                          action="append",
@@ -149,6 +152,7 @@ def klocalizerCLI():
   reportallarchs = args.report_all
   constraints_file = args.constraints_file
   constraints_file_smt2 = args.constraints_file_smt2
+  cached_formula_download=args.cached_formula_download
   output_file = args.output
   show_unsat_core = args.show_unsat_core
   approximate = args.approximate
@@ -238,6 +242,50 @@ def klocalizerCLI():
       logger.error("--sample-prefix only to be used with --sample\n")
       exit(12)
 
+  if cached_formula_download:
+    # get current version of kernel; if we can't, then error
+    command=["git", "describe", "--abbrev=0", "--tags"]
+    popen = subprocess.Popen(command, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    linux_tag_version, _ = popen.communicate()
+    linux_tag_version = linux_tag_version.strip().decode('utf-8')
+    if popen.returncode != 0:
+      logger.error("Unable to get Linux version from git describe for downloading cached formulas.\n")
+      exit(14)
+    # get version of .kmax (if available); if we can't, then assume we need to download a cached version
+    try:
+      with open(".kmax/linux_version") as lvf:
+        current_cache_version = lvf.readlines()[0].strip()
+    except:
+      current_cache_version = None
+    if linux_tag_version != current_cache_version:
+      # get cache index; if we can't, then fatal error
+      link = Klocalizer.get_kclause_cache_url(linux_tag_version)
+      # lookup version in the cache; if we can't, then tell user it's not available
+      import requests
+      req = requests.get(link)
+      # logger.info("Looking up cache index: %s\n" % (link))
+      if req.status_code == 200:
+        url_to_cached_formulas = (req.text if req.encoding is None else req.text.decode(req.encoding)).strip()
+        # logger.info("Found cached formulas: %s\n" % (url_to_cached_formulas))
+        # logger.info("Downloading...\n")
+        logger.info("Found cached formulas for %s.  Downloading...\n" % (linux_tag_version))
+        # download from the url; if we can't, then error
+        import shutil
+        local_filename = url_to_cached_formulas.split('/')[-1]
+        with requests.get(url_to_cached_formulas, stream=True) as r:
+            with open(local_filename, 'wb') as f:
+              shutil.copyfileobj(r.raw, f)
+        # untar; if we can't, then error
+        import tarfile
+        logger.info("Unpacking %s...\n" % (local_filename))
+        with tarfile.open(local_filename) as t:
+          t.extractall()
+          t.close()
+      else:
+        logger.error("No cached formulas avaiable for %s :(  Caching the formulas the slow way...\n" % (linux_tag_version))
+    else:
+      logger.info("Formula cache for %s already exists locally\n" % (linux_tag_version))
+    
   if not os.path.exists(formulas):
     logger.warning("No formulas found.  Generating them on demand.  They can also be downloaded from https://configtools.org/kmax/formulas/ for some Linux versions.\n")
     os.makedirs(formulas)

--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -230,7 +230,7 @@ def klocalizerCLI():
             t.extractall(formulas)
             t.close()
         else:
-          logger.error("No cached formulas avaiable for %s :(  Caching the formulas the slow way...\n" % (linux_tag_version))
+          logger.warning("No cached formulas for %s available for download :(\n" % (linux_tag_version))
   
   # flatten allow_unmet_for list of lists
   allow_unmet_for = [ item for elem in allow_unmet_for for item in elem ]
@@ -293,7 +293,7 @@ def klocalizerCLI():
       exit(12)
 
   if not os.path.exists(formulas):
-    logger.warning("No formulas found.  Generating them on demand.  They can also be downloaded from https://configtools.org/kmax/formulas/ for some Linux versions.\n")
+    # logger.warning("No formulas found.  Generating them on demand.  They can also be downloaded from https://configtools.org/kmax/formulas/ for some Linux versions.\n")
     os.makedirs(formulas)
 
   if approximate and not os.path.isfile(approximate):

--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -54,10 +54,6 @@ def klocalizerCLI():
   argparser.add_argument('--constraints-file-smt2',
                          type=str,
                          help="""A text file containing constraints in SMTLib format.""")
-  argparser.add_argument('-c',
-                         '--cached-formula-download',
-                         action="store_true",
-                         help="""Check configtools.org for a cached copy of this Linux version's kclause formulas to the local cache .kmax/.  Requires a git clone of Linux to discover version via tag.  Warning: this will overwrite the .kmax/ cache directory.""")
   argparser.add_argument('-a',
                          '--arch',
                          action="append",
@@ -152,7 +148,6 @@ def klocalizerCLI():
   reportallarchs = args.report_all
   constraints_file = args.constraints_file
   constraints_file_smt2 = args.constraints_file_smt2
-  cached_formula_download=args.cached_formula_download
   output_file = args.output
   show_unsat_core = args.show_unsat_core
   approximate = args.approximate
@@ -180,7 +175,62 @@ def klocalizerCLI():
 
   # set default value for formulas if not specified
   if not formulas:
-    formulas = os.path.join(linux_ksrc, ".kmax/")
+    # try to determine the version of the linux source code
+    # first try git
+    command=["git", "describe", "--abbrev=0", "--tags"]
+    popen = subprocess.Popen(command, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    linux_tag_version, _ = popen.communicate()
+    linux_tag_version = linux_tag_version.strip().decode('utf-8')
+    if popen.returncode == 0:
+      # successfully found linux version git
+      pass
+    else:
+      # apparently not a git repository, so try with make kernelversion
+      command=["make", "kernelversion"]
+      popen = subprocess.Popen(command, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+      linux_tag_version, _ = popen.communicate()
+      linux_tag_version = linux_tag_version.strip().decode('utf-8')
+      if popen.returncode == 0:
+        # successfully found linux version from make
+        pass
+      else:
+        # could not get any linux_tag_version
+        linux_tag_version = None
+    assert(type(linux_tag_version) == str or linux_tag_version is None)
+    if linux_tag_version is None:
+      # provide a hard-coded version name since we couldn't determine the version
+      formulas = os.path.join(linux_ksrc, ".kmax/", "_unknown_version")
+    else:
+      # set the formula folder based on the linux version
+      formulas = os.path.join(linux_ksrc, ".kmax/", linux_tag_version)
+
+      # try downloading a cached version if user hasn't already started generating formulas
+      if not os.path.exists(formulas):
+        # get cache index; if we can't, then fatal error
+        link = Klocalizer.get_kclause_cache_url(linux_tag_version)
+        # lookup version in the cache; if we can't, then tell user it's not available
+        import requests
+        req = requests.get(link)
+        # logger.info("Looking up cache index: %s\n" % (link))
+        if req.status_code == 200:
+          url_to_cached_formulas = (req.text if req.encoding is None else req.text.decode(req.encoding)).strip()
+          # logger.info("Found cached formulas: %s\n" % (url_to_cached_formulas))
+          # logger.info("Downloading...\n")
+          logger.info("Found cached formulas for %s.  Downloading...\n" % (linux_tag_version))
+          # download from the url; if we can't, then error
+          import shutil
+          local_filename = url_to_cached_formulas.split('/')[-1]
+          with requests.get(url_to_cached_formulas, stream=True) as r:
+              with open(local_filename, 'wb') as f:
+                shutil.copyfileobj(r.raw, f)
+          # untar; if we can't, then error
+          import tarfile
+          logger.info("Unpacking %s...\n" % (local_filename))
+          with tarfile.open(local_filename) as t:
+            t.extractall(formulas)
+            t.close()
+        else:
+          logger.error("No cached formulas avaiable for %s :(  Caching the formulas the slow way...\n" % (linux_tag_version))
   
   # flatten allow_unmet_for list of lists
   allow_unmet_for = [ item for elem in allow_unmet_for for item in elem ]
@@ -242,50 +292,6 @@ def klocalizerCLI():
       logger.error("--sample-prefix only to be used with --sample\n")
       exit(12)
 
-  if cached_formula_download:
-    # get current version of kernel; if we can't, then error
-    command=["git", "describe", "--abbrev=0", "--tags"]
-    popen = subprocess.Popen(command, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    linux_tag_version, _ = popen.communicate()
-    linux_tag_version = linux_tag_version.strip().decode('utf-8')
-    if popen.returncode != 0:
-      logger.error("Unable to get Linux version from git describe for downloading cached formulas.\n")
-      exit(14)
-    # get version of .kmax (if available); if we can't, then assume we need to download a cached version
-    try:
-      with open(".kmax/linux_version") as lvf:
-        current_cache_version = lvf.readlines()[0].strip()
-    except:
-      current_cache_version = None
-    if linux_tag_version != current_cache_version:
-      # get cache index; if we can't, then fatal error
-      link = Klocalizer.get_kclause_cache_url(linux_tag_version)
-      # lookup version in the cache; if we can't, then tell user it's not available
-      import requests
-      req = requests.get(link)
-      # logger.info("Looking up cache index: %s\n" % (link))
-      if req.status_code == 200:
-        url_to_cached_formulas = (req.text if req.encoding is None else req.text.decode(req.encoding)).strip()
-        # logger.info("Found cached formulas: %s\n" % (url_to_cached_formulas))
-        # logger.info("Downloading...\n")
-        logger.info("Found cached formulas for %s.  Downloading...\n" % (linux_tag_version))
-        # download from the url; if we can't, then error
-        import shutil
-        local_filename = url_to_cached_formulas.split('/')[-1]
-        with requests.get(url_to_cached_formulas, stream=True) as r:
-            with open(local_filename, 'wb') as f:
-              shutil.copyfileobj(r.raw, f)
-        # untar; if we can't, then error
-        import tarfile
-        logger.info("Unpacking %s...\n" % (local_filename))
-        with tarfile.open(local_filename) as t:
-          t.extractall()
-          t.close()
-      else:
-        logger.error("No cached formulas avaiable for %s :(  Caching the formulas the slow way...\n" % (linux_tag_version))
-    else:
-      logger.info("Formula cache for %s already exists locally\n" % (linux_tag_version))
-    
   if not os.path.exists(formulas):
     logger.warning("No formulas found.  Generating them on demand.  They can also be downloaded from https://configtools.org/kmax/formulas/ for some Linux versions.\n")
     os.makedirs(formulas)

--- a/kmax/klocalizer.py
+++ b/kmax/klocalizer.py
@@ -390,6 +390,11 @@ class Klocalizer:
     
     return "".join(configfile_content)
 
+  @staticmethod
+  def get_kclause_cache_url(linux_tag_version):
+    """Get the URL that holds the index to the cached formula's for the given linux version tag."""
+    return "https://configtools.org/klocalizer/cache/%s" % (linux_tag_version)
+  
   class Z3ModelSampler:
     """Given constraints, check SAT and sample models using z3 solver.
 


### PR DESCRIPTION
Firstly, the default directory holding formulas is now Linux version specific.  For example, the kclause formulas will be at .kmax/next-20210512/kclause

This is useful to avoid using the wrong formula cache when checking out another version of Linux in a git repository.  klocalizer will first check the version with git describe or make kernelversion if it is not a git clone.  The consequence is that all formula caches will remain on disk until manually deleted by the user.

Since the tool detects the version, it can tell whether the formulas are already cached.  If not, it will try to find prebuilt formulas at https://configtools.org/klocalizer/cache/VERSION.  If the user has a folder for that version, however, i.e., if they already generated some of the formulas, then no download will occur (even if not all the architectures' formulas have been generated by the user yet).