### PR TITLE
Prevent adding a variable entry that has a False presence condition

### DIFF
--- a/kmax/alg.py
+++ b/kmax/alg.py
@@ -940,8 +940,11 @@ class Kbuild:
 
 
             else:
-                self.variables[new_var_name] = [VarEntry(
-                    value, presence_cond, presence_zcond, VarEntry.RECURSIVE)]       
+                if not isfalse(presence_cond, presence_zcond):
+                    self.variables[new_var_name] = [VarEntry(
+                        value, presence_cond, presence_zcond, VarEntry.RECURSIVE)]
+                else:
+                    mlog.warn("no feasible entries to add for {} {} {}".format(name, token, value))
                 
                     
         elif token == "?=":


### PR DESCRIPTION
In some cases, e.g., arch/mips/Makefile, a presence condition for a
branch will be False.  But if there is a variable assignment in that
branch, the symbol table may receive a definition that is only valid
under False, which is never possible.  This causes the variable to be
treated as defined, which in turn causes an exception when using the
variable in another conditional expression.  Instead, we filter out
any attempts to add infeasible entries so that the variable will be
treated as never having been defined in the first place.