### PR TITLE
klocalizer.py: check for arch-specific units in python API

### DIFF
--- a/kmax/klocalizer.py
+++ b/kmax/klocalizer.py
@@ -535,6 +535,14 @@ class Klocalizer:
     """
     constraints = []
 
+    # check based on the included compilation units' directory hierarchy. this is linux specific.
+    for unit in self.__include_compilation_units:
+      if unit.startswith("arch/"):
+        unit_archs = Arch.get_archs_from_subdir(unit)
+        if not arch.name in unit_archs:
+          self.__logger.warning("Resolved compilation unit (%s) is architecture-specific (%s), unsat for the provided architecture (%s).\n" % (unit, " ".join(unit_archs), arch.name))
+          return [z3.BoolVal(False)]
+
     # add kmax constraints
     constraints.extend(self.__kmax_constraints)
 


### PR DESCRIPTION
Given a arch-specific compilation unit to klocalizer (e.g., some C file
under arch/arm/ is arm-specific), klocalizer rules out non-arm
architectures.

Do the same by the python API for klocalizer.