### PR TITLE
klocalizer: sourceline_pc: handle and report errors

### DIFF
--- a/kmax/klocalizer.py
+++ b/kmax/klocalizer.py
@@ -903,12 +903,22 @@ class Klocalizer:
       from ast import literal_eval
       return Klocalizer.ConditionalBlock._ConditionalBlock__parse_cb(literal_eval(tmpfile.read().decode()))
 
+  class SourcelinePcResult(enum.Enum):
+    SUCCESS=0       #< All success.
+    ERROR_UNSAT=1   #< Given archs do not compile the unit.
+    ERROR_MAKE=2    #< Make results in error while trying to compile the unit.
+    ERROR_SUPERC=3  #< SuperC fails to create sourceline presence conditions,
+                    #< or SuperC cannot be found. The returned architecture
+                    #< is still valid to compile the unit.
+
   @staticmethod
   def get_sourceline_pc_linux_file(srcfile: str, linux_ksrc: str, archs, \
       superc_linux_script: str, makecross_script: str, \
       restrict_to_config_prefix=True, \
       superc_configs_dir="superc_configs/", \
       skip_kconfig_config_gen=False, skip_building_unit=False, skip_superc_config_gen=False, \
+      make_out_path=None, make_err_path=None, \
+      superc_out_path=None, superc_err_path=None, \
       logger=VoidLogger()):
     """Get sourceline presence conditions for a source file within a Linux
     kernel source.
@@ -943,9 +953,26 @@ class Klocalizer:
     skip_building_unit -- Set to skip building the unit.
     skip_superc_config_gen -- Set to skip SuperC config generation for the
     unit to reuse existing configs. If not set, a config is always generated.
+    make_out_path -- Path to the file where to write make's stdout while
+    compiling the unit. Created if the unit cannot be compiled, i.e., 
+    when status is ERROR_MAKE.
+    make_err_path -- Path to the file where to write make's stderr while
+    compiling the unit. Created if the unit cannot be compiled, i.e.,
+    when status is ERROR_MAKE.
+    superc_out_path -- Path to the file where to write superc's stdout
+    while computing sourceline pc. Created if it fails, i.e., when status
+    is ERROR_SUPERC.
+    superc_err_path -- Path to the file where to write superc's stderr
+    while computing sourceline pc. Created if it fails, i.e., when status
+    is ERROR_SUPERC.
     logger -- Logger.
 
-    Returns ConditionalBlock.
+    Returns a tuple of three values:
+      - An instance of SourcelinePcResult, representing the success/error.
+      - An Arch instance, representing the architecture that compiles the
+        unit. May be None in error cases, e.g., ERROR_UNSAT.
+      - A ConditionalBlock instance, representing the sourceline presence
+        conditions for the sourcefile. May be None in error cases.
     """
     # TODO: take additional flags to SuperC
     # TODO: any existing .config file is overwritten. write new Kconfig configs to a path different than linux_ksrc/.config?
@@ -956,6 +983,14 @@ class Klocalizer:
     Klocalizer.__check_args_get_sourceline_pc(srcfile, linux_ksrc, True, \
       archs, superc_linux_script, makecross_script, \
       skip_kconfig_config_gen, skip_building_unit, skip_superc_config_gen)
+
+    def write_content_to_file(content : str, fpath : str):
+      if fpath is None:
+        return False
+      os.makedirs(os.path.dirname(fpath), exist_ok=True)
+      with open(fpath, 'w') as f:
+        f.write(content)
+      return True
 
     #
     # Detect the architecture
@@ -980,7 +1015,7 @@ class Klocalizer:
     # Not possible to compile with the given set of architectures
     if not is_sat:
       logger.warning("Could not find an architecture that compiles the unit.")
-      return None, None
+      return Klocalizer.SourcelinePcResult.ERROR_UNSAT, None, None
     else:
       assert arch
       logger.info("The unit compiles for the architecture: \"%s\"" % arch.name)
@@ -1010,10 +1045,22 @@ class Klocalizer:
       assert srcfile.endswith(".c") # TODO: what if this is not a sourcefile but a header file?
 
       compile_cmd = [makecross_script, "ARCH=%s" % arch.name, "clean", unit_name]
+      compile_cmd_str = " ".join(compile_cmd)
 
       run(olddefconf_cmd, cwd=linux_ksrc)
-      run(compile_cmd, cwd=linux_ksrc)
-      assert os.path.isfile(os.path.join(linux_ksrc, unit_name))
+      make_out, make_err, ret = run(compile_cmd, cwd=linux_ksrc)
+
+      # Write make's stdout and stderr
+      if ret != 0:
+        # Might happen with warnings like unmet dependency bug. Make is
+        # said to fail if the unit cannot be found compiled.
+        logger.warning("Make returned non-zero(%s)" % ret)
+      unit_path = os.path.join(linux_ksrc, unit_name)
+      if not os.path.isfile(unit_path):
+        logger.error("Cannot find a compiled unit at \"%s\"" % unit_path)
+        write_content_to_file(compile_cmd_str +"\n"+ make_out.decode('utf-8'), make_out_path)
+        write_content_to_file(compile_cmd_str +"\n"+ make_err.decode('utf-8'), make_err_path)
+        return Klocalizer.SourcelinePcResult.ERROR_MAKE, None, None
     else:
       logger.info("Skipped: compiling the unit.")
 
@@ -1029,6 +1076,7 @@ class Klocalizer:
       pathlib.Path(superc_configs_dir).mkdir(parents=True, exist_ok=True)
       assert os.path.isdir(superc_configs_dir)
       config_gen_cmd = [superc_linux_script, "-w", "-x", makecross_script, "-a", arch.name, "-L", superc_configs_dir, srcfile]
+      logger.info("SuperC config gen command: \"%s\"" % " ".join(config_gen_cmd))
       run(config_gen_cmd, cwd=linux_ksrc)
       assert os.path.isfile(superc_config_path)
     else:
@@ -1054,14 +1102,29 @@ class Klocalizer:
       restrict_flag = " -restrictConfigToPrefix CONFIG_ " if restrict_to_config_prefix else ""
       superc_flags = "%s -sourcelinePC %s" % (restrict_flag, tmpfilename)
       superc_sourcelinepc_cmd = [superc_linux_script, "-S%s" % superc_flags, "-L%s" % superc_configs_dir, srcfile]
+      superc_sourcelinepc_cmd_str = " ".join(superc_sourcelinepc_cmd)
+      logger.info("SuperC command: \"%s\"" % " ".join(superc_sourcelinepc_cmd))
+      # TODO: timeout
+      superc_out, superc_err, ret = run(superc_sourcelinepc_cmd, cwd=linux_ksrc)
 
-      run(superc_sourcelinepc_cmd, capture_stdout=True, capture_stderr=True, cwd=linux_ksrc)
+      if ret != 0:
+        # Might happen with warnings/errors where we still get some results.
+        logger.warning("SuperC returned non-zero(%s)" % ret)
+
       superc_pcfile_content = tmpfile.read().decode()
+      if not superc_pcfile_content:
+        logger.error("Empty SuperC output." % unit_path)
+        write_content_to_file(superc_sourcelinepc_cmd_str +"\n"+ superc_out.decode('utf-8'), superc_out_path)
+        write_content_to_file(superc_sourcelinepc_cmd_str +"\n"+ superc_err.decode('utf-8'), superc_err_path)
+        return Klocalizer.SourcelinePcResult.ERROR_SUPERC, arch, None
+
     assert superc_pcfile_content
     assert arch
     from ast import literal_eval
     # return __parse_cb(literal_eval(superc_pcfile_content))
-    return arch, Klocalizer.ConditionalBlock._ConditionalBlock__parse_cb(literal_eval(superc_pcfile_content))
+    ret_code = Klocalizer.SourcelinePcResult.SUCCESS
+    pc = Klocalizer.ConditionalBlock._ConditionalBlock__parse_cb(literal_eval(superc_pcfile_content))
+    return ret_code, arch, pc
 
   #
   # Exceptions

--- a/kmax/klocalizer.py
+++ b/kmax/klocalizer.py
@@ -1113,7 +1113,7 @@ class Klocalizer:
 
       superc_pcfile_content = tmpfile.read().decode()
       if not superc_pcfile_content:
-        logger.error("Empty SuperC output." % unit_path)
+        logger.error("Empty SuperC output.")
         write_content_to_file(superc_sourcelinepc_cmd_str +"\n"+ superc_out.decode('utf-8'), superc_out_path)
         write_content_to_file(superc_sourcelinepc_cmd_str +"\n"+ superc_err.decode('utf-8'), superc_err_path)
         return Klocalizer.SourcelinePcResult.ERROR_SUPERC, arch, None


### PR DESCRIPTION
Use SourcelinePcResult enum to return status from sourceline pc
computing method: Klocalizer.get_sourceline_pc_linux_file().

Dump stdout/err of make/superc if they fail.