### PR TITLE
klocalizer: add --disable-downloading-formulas flag

### DIFF
--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -44,6 +44,10 @@ def klocalizerCLI():
                          type=str,
                          default=None,
                          help="""The file containing the a pickled tuple with a mapping from configuration option to its formulas and a list of additional constraints.  This overrides --arch.""")
+  argparser.add_argument('--disable-downloading-formulas',
+                         action="store_true",
+                         help="""Disable downloading kclause formulas and instead generate formulas when formulas cannot be found on disk.  """
+                              """By default, when formulas cannot be found on disk, klocalizer downloads the formulas from the remote cache if available.""")
   argparser.add_argument('--use-composite-kclause-formulas-files',
                          action="store_true",
                          help="""Use composite kclause formulas files where all constraints are in a single list instead of a mapping from configuration option to its formulas. """
@@ -155,6 +159,7 @@ def klocalizerCLI():
   formulas = args.formulas
   kmax_file = args.kmax_formulas
   kclause_file = args.kclause_formulas
+  disable_downloading_formulas = args.disable_downloading_formulas
   use_composite_kclause_formulas_files = args.use_composite_kclause_formulas_files
   kextract_file = args.kextract
   kextract_version = args.kextract_version
@@ -223,7 +228,7 @@ def klocalizerCLI():
       formulas = os.path.join(linux_ksrc, ".kmax/", linux_tag_version)
 
       # try downloading a cached version if user hasn't already started generating formulas
-      if not os.path.exists(formulas):
+      if not disable_downloading_formulas and not os.path.exists(formulas):
         # get cache index; if we can't, then fatal error
         link = Klocalizer.get_kclause_cache_url(linux_tag_version)
         # lookup version in the cache; if we can't, then tell user it's not available


### PR DESCRIPTION
Let user be able to disable downloading formulas and instead generate
formulas by using the --disable-downloading-formulas flag.

This is useful when:
* User wants a freshly generated formulas since the kernel version is
not an indicator of the Kconfig specs (e.g., user manually changed the
Kconfig specs, user is experimenting changes to some modules etc.)
* User does not want to use the network (slow internet, does not trust
downloaded content etc.)