### PR TITLE
fix: superc config gen: copy .config for superc_linux.sh to find

### DIFF
--- a/kmax/superc.py
+++ b/kmax/superc.py
@@ -6,6 +6,7 @@ import pathlib
 from shutil import which
 from kmax.klocalizer import Klocalizer
 import subprocess
+import shutil
 
 class SuperC:
   class SuperC_Exception(Exception):
@@ -441,6 +442,7 @@ class SuperC:
         logger.debug("Failed to localize a building Linux .config file.\n")
         return False
       else:
+        assert os.path.isfile(output_config_file)
         logger.debug("A building Linux .config file was localized.\n")
       
       # Check if the unit compiles (also build them to prep for SuperC config creation)
@@ -463,6 +465,7 @@ class SuperC:
       # Create missing SuperC config files
       logger.debug("Creating the missing SuperC config file.\n")
       pathlib.Path(output_superc_configs_dir_path).mkdir(parents=True, exist_ok=True)
+      assert shutil.copy(output_config_file, os.path.join(linux_ksrc, ".config"))
       ret = self.create_superc_config_on_built_unit(srcfile, output_superc_configs_dir_path, linux_ksrc, arch.name, cross_compiler)
       config_created, superc_ret, superc_out, superc_err, time_elapsed = ret
       write_content_to_file(logpath("superc_config_gen_status"), str(config_created) + '\n')


### PR DESCRIPTION
SuperC linux script searches the Linux config file in LINUX_KSRC/.config
implicity (it runs make, which uses the kconfig file at this path by
default).  We knew that before and had an assertion in python module
that the .config file exists at this path.

On the other hand, SuperC python module keeps the config file elsewhere
for diagnostic purposes.

Make a copy of this config file at LINUX_KSRC/.config before running
superc_linux.sh for superc config creation.

(This commit also adds an unrelated yet useful assertion.)

Fixes #127 