### PR TITLE
let arch get kextract module versions from kextractcommon, fix newlines in kismet log messages

### DIFF
--- a/kmax/arch.py
+++ b/kmax/arch.py
@@ -757,7 +757,7 @@ class Arch:
     # Try multiple kextract module versions unless version is explicitly set
     if not self.__kextract_version:
       # Give the priority to the detected version
-      kextract_module_versions=[a for a in ["3.19", "4.12.8", "next-20200430", "next-20210426"] if a != kextract_version] + [kextract_version]
+      kextract_module_versions=[a for a in kmax.kextractcommon.module_versions if a != kextract_version] + [kextract_version]
     else:
       # Version is explicity set
       kextract_module_versions=[kextract_version]

--- a/kmax/kismet
+++ b/kmax/kismet
@@ -386,9 +386,9 @@ if __name__ == '__main__':
     formulas_arg = os.path.join(linux_ksrc, ".kmax/")
 
   # Get the build system id, which names the formulas cache subdirectory
-  info("Computing the build system id for the Linux source..\n")
+  info("Computing the build system id for the Linux source..")
   build_system_id = get_build_system_id(linux_ksrc) # takes about 4sec on an SSD
-  info("Build system id: %s\n" % build_system_id)
+  info("Build system id: %s" % build_system_id)
   formulas = os.path.join(formulas_arg, build_system_id)
 
   kismet_log_level = logging.INFO


### PR DESCRIPTION
These changes fix small issues in https://github.com/paulgazz/kmax/pull/148

[arch: get kextract module versions from kextractcommon](https://github.com/paulgazz/kmax/commit/60bdf1f05db3e2d900dacb15cb3d4868815c954f)

[kismet: fix newlines in new log messages](https://github.com/paulgazz/kmax/commit/cf620ce730072f54260755d0d6e30718549fd0ce)