### PR TITLE
klocalizer: relax unit/srcfile extension check

### DIFF
--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -329,10 +329,10 @@ def klocalizerCLI():
   sys.stderr.write("klocalizer, %s %s\n" % (kmax.about.__title__, kmax.about.__version__))
 
   def unit2srcfile(unit):
-    assert unit.endswith('.o')
+    assert unit.endswith('.c') or unit.endswith('.o')
     return unit[:-len('.o')] + '.c'
   def srcfile2unit(srcfile):
-    assert srcfile.endswith('.c')
+    assert srcfile.endswith('.c') or srcfile.endswith('.o')
     return srcfile[:-len('.c')] + '.o'
   
   def get_exclusion_constraints(unit_constraints, line_constraints):


### PR DESCRIPTION
Local methods unit2srcfile() and srcfile2unit() is used to change
extensions between .c and .o.  In some cases, they are called even if
the extension is already the target one (e.g., unit2srcfile() is called
while extension is already .c).

Change the assertions inside those methods to accept this, so that
they can be used with more flexibility, without needing to keep track of
what the current extension was.

Fixes https://github.com/paulgazz/kmax/issues/156