### PR TITLE
Fix outputting select constructs for older kextractor versions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,3 +29,5 @@ include kextractors/kextractor-4.18/preprocess.c
 include kextractors/kextractor-4.18/symbol.c
 include kextractors/kextractor-4.18/util.c
 include kextractors/kextractor-4.18/zconf.lex.c
+
+recursive-include kmax/resources *

--- a/kextractors/kextractor-3.19/kextractor.c
+++ b/kextractors/kextractor-3.19/kextractor.c
@@ -1994,36 +1994,104 @@ int main(int argc, char **argv)
     /*   } */
     /* } */
 
+    // for choice symbols, add choice's visibility and dependency conditions to config_vars' direct dependency
+    // This is disabled because kclause already accounts for this dependency by adding the implication
+    // clause of "implication(possible_choices, dep_expr)". This is saying that possible_choices cannot
+    // be enabled without having dep_expr enabled.
+    // for_all_symbols(i, sym) {
+    //   if (sym_is_choice(sym)) {
+    //     struct expr *e;
+    //     struct symbol *def_sym;
+    //     struct property* prop = sym_get_choice_prop(sym);
+
+    //     if (prop && prop->visible.expr) {
+    //       expr_list_for_each_sym(prop->expr, e, def_sym) {
+    //         if (!def_sym->dir_dep.expr) {
+    //           // use the visibility expression
+    //           def_sym->dir_dep.expr = expr_copy(prop->visible.expr);
+    //         } else {
+    //           // conjuct the direct dependency with the visibility condition of the <choice>
+    //           def_sym->dir_dep.expr = expr_alloc_and(def_sym->dir_dep.expr, prop->visible.expr);
+    //         }
+    //       }
+    //     }
+    //   }
+    // }
     // print all dependent config vars
     for_all_symbols(i, sym) {
       // TODO: deal with choice nodes
-      if (sym_is_choice(sym) && sym->type == S_BOOLEAN) {
+      if (sym_is_choice(sym)) {
         struct property *prop;
         struct symbol *def_sym;
         struct expr *e;
 
         prop = sym_get_choice_prop(sym);
+	
+	// print choice type, depending on config type and optional statement
+	switch(sym->type) {
+          case S_BOOLEAN:
+            sym_is_optional(sym) ? fprintf(output_fp, "bool_opt_choice") : fprintf(output_fp, "bool_choice");
+            break;
+          case S_TRISTATE:
+            sym_is_optional(sym) ? fprintf(output_fp, "tristate_opt_choice") : fprintf(output_fp, "tristate_choice");
+            break;
+          default:
+            fprintf(stderr, "fatal: choice type can only be bool or tristate, otherwise is impossible due to the parser.\n");
+            exit(1);
+        }
 
-        fprintf(output_fp, "bool_choice");
         expr_list_for_each_sym(prop->expr, e, def_sym) {
           fprintf(output_fp, " %s%s", config_prefix, def_sym->name);  // any dependencies should be handled below with 'dep'
         }
         fprintf(output_fp, "|(");
-        if ((NULL != sym->dir_dep.expr) && (NULL != sym->rev_dep.expr)) {
-          fprintf(output_fp, "(");
-          print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
-          fprintf(output_fp, ") and (");
-          print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
-        } else if (NULL != sym->dir_dep.expr) {
-          print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
-        } else if (NULL != sym->rev_dep.expr) {
-          print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
-        } else {
-          fprintf(output_fp, "1");
+
+	// Both depends on and visibility shoul be satisfied for 
+	// the choice to be selectable.
+	// Kconfig conjuncts depends on constraint to the 
+	// visibility constraint, so that for choice, looking at
+	// only the visibility is sufficient.
+	// rev_dep of choice copies the visibility to prevent
+	// non-optional choices have no selection (menu.c, l854) 
+	// Thus, rev_dep is the same as visibiltiy except conjoing
+	// 'm' which is currently not needed for kclause.
+	// In sum, only visibility is needed as the condition of
+	// choice.
+
+        // for formatting
+        int printed_expr = 0;
+	prop = NULL;
+        for_all_prompts(sym, prop) {
+          if ((NULL != prop)) {
+
+	    if (printed_expr) {
+	      fprintf(stderr, "warning: encountered multiple prompts, ignoring.");
+	      break;
+	      // commented code below can handle the case where multiple
+	      // prompts are defined, where satisfying any of them makes
+	      // the config option visible. However, multiple prompts 
+	      // raises a warning by Kconfig and we consider it as an 
+	      // invalid use of Kconfig language. Thus, this code is 
+              // commented for now. Note that, using this code here
+              // means the code for prompt keyword should also reflect
+              // this case.
+	      //fprintf(output_fp, " or ");
+	    }
+	    
+	    printed_expr = 1;
+	    fprintf(output_fp, "(");
+            if (NULL != prop->visible.expr) {
+              print_python_expr(prop->visible.expr, output_fp, E_NONE);
+            } else {
+              fprintf(output_fp, "1");
+            }
+            fprintf(output_fp, ")");
+          }
         }
-        fprintf(output_fp, ")");
-        fprintf(output_fp, "\n");
+
+        if (!printed_expr)
+          fprintf(output_fp, "1");
+        
+        fprintf(output_fp, ")\n");
       }
       
       if (!sym->name || strlen(sym->name) == 0)

--- a/kextractors/kextractor-3.19/kextractor.c
+++ b/kextractors/kextractor-3.19/kextractor.c
@@ -2044,23 +2044,23 @@ int main(int argc, char **argv)
 
         if (enable_reverse_dependencies) {
           // print all the variables selected by this variable
-          /* struct property *prop; */
-          /* for_all_properties(sym, prop, P_SELECT) { */
-          /*   // the current var itself is the var doing the select */
-          /*   // prop->expr is the variable being selected */
-          /*   // prop->visible.expr is the "if ..." after the select */
-          /*   fprintf(output_fp, "select "); */
-          /*   // note: this assumes that prop->expr is only a single */
-          /*   // variable name, which zconf.y guarantees */
-          /*   print_python_expr(prop->expr, output_fp, E_NONE); */
-          /*   fprintf(output_fp, " %s%s (", config_prefix, sym->name); */
-          /*   if (NULL != prop->original_expr) { */
-          /*     print_python_expr(prop->original_expr, output_fp, E_NONE); */
-          /*   } else { */
-          /*     fprintf(output_fp, "1"); */
-          /*   } */
-          /*   fprintf(output_fp, ")\n"); */
-          /* } */
+          struct property *prop;
+          for_all_properties(sym, prop, P_SELECT) {
+            // the current var itself is the var doing the select
+            // prop->expr is the variable being selected
+            // prop->visible.expr is the "if ..." after the select
+            fprintf(output_fp, "select ");
+            // note: this assumes that prop->expr is only a single
+            // variable name, which zconf.y guarantees
+            print_python_expr(prop->expr, output_fp, E_NONE);
+            fprintf(output_fp, " %s%s (", config_prefix, sym->name);
+            if (NULL != prop->visible.expr) {
+              print_python_expr(prop->visible.expr, output_fp, E_NONE);
+            } else {
+              fprintf(output_fp, "1");
+            }
+            fprintf(output_fp, ")\n");
+          }
 
           if (sym->rev_dep.expr) {
             no_dependencies = false;

--- a/kextractors/kextractor-4.12.8/kextractor.c
+++ b/kextractors/kextractor-4.12.8/kextractor.c
@@ -2064,23 +2064,23 @@ int main(int argc, char **argv)
 
         if (enable_reverse_dependencies) {
           // print all the variables selected by this variable
-          /* struct property *prop; */
-          /* for_all_properties(sym, prop, P_SELECT) { */
-          /*   // the current var itself is the var doing the select */
-          /*   // prop->expr is the variable being selected */
-          /*   // prop->visible.expr is the "if ..." after the select */
-          /*   fprintf(output_fp, "select "); */
-          /*   // note: this assumes that prop->expr is only a single */
-          /*   // variable name, which zconf.y guarantees */
-          /*   print_python_expr(prop->expr, output_fp, E_NONE); */
-          /*   fprintf(output_fp, " %s%s (", config_prefix, sym->name); */
-          /*   if (NULL != prop->original_expr) { */
-          /*     print_python_expr(prop->original_expr, output_fp, E_NONE); */
-          /*   } else { */
-          /*     fprintf(output_fp, "1"); */
-          /*   } */
-          /*   fprintf(output_fp, ")\n"); */
-          /* } */
+          struct property *prop;
+          for_all_properties(sym, prop, P_SELECT) {
+            // the current var itself is the var doing the select
+            // prop->expr is the variable being selected
+            // prop->visible.expr is the "if ..." after the select
+            fprintf(output_fp, "select ");
+            // note: this assumes that prop->expr is only a single
+            // variable name, which zconf.y guarantees
+            print_python_expr(prop->expr, output_fp, E_NONE);
+            fprintf(output_fp, " %s%s (", config_prefix, sym->name);
+            if (NULL != prop->visible.expr) {
+              print_python_expr(prop->visible.expr, output_fp, E_NONE);
+            } else {
+              fprintf(output_fp, "1");
+            }
+            fprintf(output_fp, ")\n");
+          }
 
           if (sym->rev_dep.expr) {
             no_dependencies = false;

--- a/kmax/kismet
+++ b/kmax/kismet
@@ -9,8 +9,8 @@ import sys
 import datetime
 from kmax.klocalizer import Klocalizer
 from kmax.arch import Arch
-from kmax.udd_warning_parser import parse_warnings
 from kmax.vcommon import get_build_system_id
+from kmax import udd_warning_parser
 import logging
 import subprocess
 import csv
@@ -61,6 +61,10 @@ def warning(msg, ending="\n"):
 
 def error(msg, ending="\n"):
   sys.stderr.write("ERROR: %s%s" % (msg, ending))
+
+def debug(msg, enabled, ending="\n"):
+  if enabled:
+    sys.stderr.write("DEBUG: %s%s" % (msg, ending))
 
 # model might be the shortcut solution, e.g., the sat model for Or(A,B,C)
 # might be just A. Get a complete model the input model.
@@ -318,6 +322,9 @@ if __name__ == '__main__':
   argparser.add_argument('--allow-config-broken',
                         action="store_true",
                         help="""Allow CONFIG_BROKEN dependencies.  """)
+  argparser.add_argument('--verbose',
+                        action="store_true",
+                        help="""Verbose mode prints additional messages to stderr.""")
   
   args = argparser.parse_args()
   arch_name = args.arch
@@ -343,6 +350,7 @@ if __name__ == '__main__':
   summary_txt_path = args.summary_txt if args.summary_txt != None else "kismet_summary_%s.txt" % arch_name
   summary_use_testcase_realpath= args.use_fullpath_in_summary
   disable_config_broken = not args.allow_config_broken
+  verbose = args.verbose
 
   if not precise_SAT_pass:
     if generate_sample:
@@ -802,6 +810,7 @@ if __name__ == '__main__':
     selectee and selector assumed to have CONFIG_ prefix.
     """
     assert os.path.isfile(cfgfilepath)
+    debug("Verifying the alarm for (%s,%s) with config file %s (arch=%s)" % (selectee, selector, cfgfilepath, arch_name), verbose)
 
     # use a copy so the original won't change
     kismetcopy_path = "kismet_verifcopy_" + os.path.basename(cfgfilepath)
@@ -810,11 +819,13 @@ if __name__ == '__main__':
 
     command = ["make", "ARCH=%s" % arch_name, "KCONFIG_CONFIG=%s" % os.path.realpath(kismets_copy), "olddefconfig"]
     popen = subprocess.Popen(command, stdin=DEVNULL, stdout=DEVNULL, stderr=subprocess.PIPE, cwd=linux_ksrc)
-    stderr = popen.communicate()[1].decode("utf-8")
-    parsed_warnings = parse_warnings(str(stderr))
+    make_stderr = str(popen.communicate()[1].decode("utf-8"))
+    debug("Kconfig output is: \"%s\"" % make_stderr, verbose)
+    parsed_warnings = udd_warning_parser.parse_warnings(make_stderr)
     rm_cfg_prefix = lambda text: text[text.startswith("CONFIG_") and len("CONFIG_"):]
     nocfg_selector, nocfg_selectee = rm_cfg_prefix(selector), rm_cfg_prefix(selectee)
     verified = nocfg_selectee in parsed_warnings and nocfg_selector in parsed_warnings[nocfg_selectee]
+    debug("Verification result: %s" % verified, verbose)
 
     # remove the copy
     os.remove(kismets_copy)
@@ -827,7 +838,27 @@ if __name__ == '__main__':
     current_time = datetime.datetime.now().strftime("%H:%M:%S")
     info("%s Verification from test cases progress: %s." % (current_time, dumps_progress(num_checked, count_testcasgen_configscreated)), ending="\r")
 
+  kconfig_ready_for_verification = False
+  kconfig_extension_applied = False
   if verify:
+    # If needed, apply the Kconfig extension patch, which modifies Kconfig
+    # code to print unmet direct dependency warnings in explicit format
+    # that is amenable to use in verification.
+    kconfig_extension_needed = not udd_warning_parser.does_kconfig_print_uddwarning_in_explicit_format(linux_ksrc)
+    if not kconfig_extension_needed:
+      debug("Kconfig is ready for verification without extension patch.", verbose)
+      kconfig_ready_for_verification = True
+      kconfig_extension_applied = False
+    else: #< Kconfig extension is needed.
+      debug("Kconfig extension is needed for verification: applying the patch.", verbose)
+      ret = udd_warning_parser.patch_kconfig_udd_printer_extension(linux_ksrc)
+      debug("Kconfig extension patch success result: %s" % ret, verbose)
+      kconfig_ready_for_verification = ret
+      kconfig_extension_applied = ret
+      if not ret:
+        error("Failed to apply Kconfig verification patch: kismet will skip verification.")
+
+  if verify and kconfig_ready_for_verification:
     num_verified = 0
     unique_verified = 0
     some_testcase_verifies = 0 # the count of constructs with alarms that at least one related test case verifies the alarm
@@ -894,6 +925,15 @@ if __name__ == '__main__':
     info_str += " For %d constructs, test cases had contradictory results." % (count_verification_some_verified_per_unique_construct - count_verification_all_verified_per_unique_construct)
     info_str += " For %d constructs, no test case verified the alarm." % (count_testcasgen_configscreated - count_verification_some_verified_per_unique_construct)
     info(info_str)
+
+  # If applied, reverse the kconfig extension.
+  if kconfig_extension_applied:
+    debug("Reversing the Kconfig extension patch that was applied for verification.", verbose)
+    ret = udd_warning_parser.reverse_patch_kconfig_udd_printer_extension(linux_ksrc)
+    if ret:
+      debug("Reversing the Kconfig extension patch was successful.", verbose)
+    else:
+      warning("Failed to reverse the Kconfig extension patch: the Linux source is left modified.")
 
   #
   # Dump summary txt

--- a/kmax/resources/kismet_udd_printer_extension.h
+++ b/kmax/resources/kismet_udd_printer_extension.h
@@ -1,0 +1,102 @@
+/**
+ * This is an extension to Kconfig code to print unmet dependency warnings
+ * in an explicit format amenable to bug verification by kismet.
+ * 
+ * The code was adapted from the Kconfig code of newer Linux kernel
+ * versions. Function names are prefixed with "kismet_" to avoid potential
+ * name collisions.
+ * */
+
+#ifndef KISMET_UDD_PRINTER_EXTENSION_H
+#define KISMET_UDD_PRINTER_EXTENSION_H
+
+#include <string.h>
+
+#include "lkc.h"
+
+void expr_gstr_print(struct expr*, struct gstr*); // expr.c
+tristate expr_calc_value(struct expr*); // expr.c
+
+/*
+ * Transform the top level "||" tokens into newlines and prepend each
+ * line with a minus. This makes expressions much easier to read.
+ * Suitable for reverse dependency expressions.
+ */
+static void kismet_expr_print_revdep(struct expr *e,
+			      void (*fn)(void *, struct symbol *, const char *),
+			      void *data, tristate pr_type, const char **title)
+{
+	if (e->type == E_OR) {
+		kismet_expr_print_revdep(e->left.expr, fn, data, pr_type, title);
+		kismet_expr_print_revdep(e->right.expr, fn, data, pr_type, title);
+	} else if (expr_calc_value(e) == pr_type) {
+		if (*title) {
+			fn(data, NULL, *title);
+			*title = NULL;
+		}
+
+		fn(data, NULL, "  - ");
+		expr_print(e, fn, data, E_NONE);
+		fn(data, NULL, "\n");
+	}
+}
+
+static void kismet_expr_print_gstr_helper(void *data, struct symbol *sym, const char *str)
+{
+	struct gstr *gs = (struct gstr*)data;
+	const char *sym_str = NULL;
+
+	if (sym)
+		sym_str = sym_get_string_value(sym);
+
+	if (gs->max_width) {
+		unsigned extra_length = strlen(str);
+		const char *last_cr = strrchr(gs->s, '\n');
+		unsigned last_line_length;
+
+		if (sym_str)
+			extra_length += 4 + strlen(sym_str);
+
+		if (!last_cr)
+			last_cr = gs->s;
+
+		last_line_length = strlen(gs->s) - (last_cr - gs->s);
+
+		if ((last_line_length + extra_length) > gs->max_width)
+			str_append(gs, "\\\n");
+	}
+
+	str_append(gs, str);
+	if (sym && sym->type != S_UNKNOWN)
+		str_printf(gs, " [=%s]", sym_str);
+}
+
+static void kismet_expr_gstr_print_revdep(struct expr *e, struct gstr *gs,
+			    tristate pr_type, const char *title)
+{
+	kismet_expr_print_revdep(e, kismet_expr_print_gstr_helper, gs, pr_type, &title);
+}
+
+
+static void kismet_sym_warn_unmet_dep(struct symbol *sym)
+{
+	struct gstr gs = str_new();
+
+	str_printf(&gs,
+		   "\nWARNING: unmet direct dependencies detected for %s\n",
+		   sym->name);
+	str_printf(&gs,
+		   "  Depends on [%c]: ",
+		   sym->dir_dep.tri == mod ? 'm' : 'n');
+	expr_gstr_print(sym->dir_dep.expr, &gs);
+	str_printf(&gs, "\n");
+
+	kismet_expr_gstr_print_revdep(sym->rev_dep.expr, &gs, yes,
+			       "  Selected by [y]:\n");
+	kismet_expr_gstr_print_revdep(sym->rev_dep.expr, &gs, mod,
+			       "  Selected by [m]:\n");
+
+	fputs(str_get(&gs), stderr);
+}
+
+#endif // KISMET_UDD_PRINTER_EXTENSION_H

--- a/kmax/resources/kismet_verification_patch.diff
+++ b/kmax/resources/kismet_verification_patch.diff
@@ -1,0 +1,11 @@
+diff --git a/scripts/kconfig/symbol.c b/scripts/kconfig/symbol.c
+index 2220bc4b051b..c10911a11b36 100644
+--- a/scripts/kconfig/symbol.c
++++ b/scripts/kconfig/symbol.c
+@@ -12,1 +12,2 @@
+ #include "lkc.h"
++#include "kismet_udd_printer_extension.h"
+@@ -415,1 +416,3 @@ void sym_calc_value(struct symbol *sym)
+ 		calc_newval:
++			if (sym->dir_dep.tri < sym->rev_dep.tri)
++				kismet_sym_warn_unmet_dep(sym);

--- a/kmax/udd_warning_parser.py
+++ b/kmax/udd_warning_parser.py
@@ -1,5 +1,73 @@
 # unmet direct dependency warnings parser
-import os, re, pprint, textwrap, argparse
+import os, re
+from shutil import which, copyfile
+from kmax.vcommon import run
+
+def __get_installed_module_path() -> str:
+    import sys
+    return os.path.dirname(sys.modules['kmax'].__file__)
+
+def __get_resource_path(r_relpath) -> str:
+    mpath = __get_installed_module_path()
+    return os.path.join(mpath, r_relpath)
+
+def patch_kconfig_udd_printer_extension(linux_ksrc: str) -> bool:
+    """Patch Kconfig code to print explicit unmet direct dependency bug
+    warnings.
+    """
+    assert which("patch")
+    
+    # Apply the patch.
+    pfile = __get_resource_path("resources/kismet_verification_patch.diff")
+    assert os.path.isfile(pfile)
+    target_file = os.path.join(linux_ksrc, "scripts/kconfig/symbol.c")
+    assert os.path.isfile(target_file)
+    patch_cmd = "patch -p1 %s < %s" % (target_file, pfile)
+    _, _, patch_retcode, _ = run(patch_cmd, shell=True)
+
+    # Copy the extension header file.
+    src = __get_resource_path("resources/kismet_udd_printer_extension.h")
+    assert os.path.isfile(src)
+    dst_extfile = os.path.join(linux_ksrc, "scripts/kconfig/kismet_udd_printer_extension.h")
+    copyfile(src, dst_extfile)
+    assert os.path.isfile(dst_extfile)
+
+    return patch_retcode == 0 and os.path.isfile(dst_extfile)
+
+def reverse_patch_kconfig_udd_printer_extension(linux_ksrc: str) -> bool:
+    """Reverse the patch to the Kconfig code that prints explicit unmet
+    direct dependency bug warnings.
+    """
+    assert which("patch")
+    
+    # Reverse the patch.
+    pfile = __get_resource_path("resources/kismet_verification_patch.diff")
+    assert os.path.isfile(pfile)
+    target_file = os.path.join(linux_ksrc, "scripts/kconfig/symbol.c")
+    assert os.path.isfile(target_file)
+    patch_cmd = "patch -R -p1 %s < %s" % (target_file, pfile)
+    _, _, patch_retcode, _ = run(patch_cmd, shell=True)
+
+    # Remove the extension header file.
+    extfile = os.path.join(linux_ksrc, "scripts/kconfig/kismet_udd_printer_extension.h")
+    if os.path.isfile(extfile):
+        os.remove(extfile)
+
+    return patch_retcode == 0 and not os.path.exists(extfile)
+
+def does_kconfig_print_uddwarning_in_explicit_format(linux_ksrc) -> bool:
+    """Returns whether Kconfig has code for printing unmet direct
+    dependency warnings in an explicit format that is amenable to use in
+    verifying bugs with test cases.
+
+    The explicit format starts with:
+        "WARNING: unmet direct dependencies detected for"
+    """
+    assert which("grep")
+    kconfig_scripts_path = os.path.join(linux_ksrc, "scripts/kconfig/")
+    cmd = "grep -rI \"WARNING: unmet direct dependencies detected for\""
+    _, _, retcode, _ = run(cmd, cwd = kconfig_scripts_path, shell = True)
+    return retcode == 0
 
 # given the content of the make output possibly including multiple warnings
 # parses the content and returns {selected: {selecters} }

--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,5 @@ setup(
         'whatthepatch',
         'packaging',
     ],
+    include_package_data=True,
 )


### PR DESCRIPTION
This uncomments the output of "select ..." lines in the kextract output, which is used by kismet to get the list of select constructs.  It was originally commented out in favor of "rev_dep ..." lines for kclause, which no longer needs the selects lines.

Fixes #161
Fixes #159 