### PR TITLE
Check whether the architecture exists when running kextract

### DIFF
--- a/kmax/arch.py
+++ b/kmax/arch.py
@@ -771,6 +771,9 @@ class Arch:
       _, _, ret_code = self.__run_command(command, cwd=self.__linux_ksrc)
       if ret_code == 0:
         break
+      if ret_code == 2:
+        self.__logger.error("Architecture directory for \"%s\" is not available, so kextract not generated." % (self.name))
+        raise Arch.ArchitectureUnavailableError()
       else:
         self.__logger.debug("Kextract failed (module version: %s, return code: %d)." % (kextract_version, ret_code))
         if kextract_module_versions: self.__logger.debug("Trying next latest kextract module version: %s" % kextract_module_versions[-1])
@@ -1252,6 +1255,11 @@ class Arch:
       self.formula_type=formula_type
       self.message="%s formulas couldn't be generated." % (formula_type)
       super().__init__(self.message)
+
+  ### Can't generate formula: kextract
+  class ArchitectureUnavailableError(FormulaGenerationError):
+    def __init__(self):
+      super().__init__(formula_type="kextract")
 
   ### Can't generate formula: kextract
   class KextractFormulaGenerationError(FormulaGenerationError):

--- a/kmax/kextractlinux
+++ b/kmax/kextractlinux
@@ -9,6 +9,7 @@ import sys
 import argparse
 import kmax.about
 import kmax.kextractcommon
+import os
 
 def get_srcarch(arch):
   srcarch = {
@@ -69,6 +70,11 @@ if __name__ == '__main__':
   args.extend([ "--extract" ])  # tell kextract to do an extract oepration
   args.extend([ "-o", output ]) # set the output file
   # setup the linux-specific environment variables
+  # srctree is ./
+  archdir = os.path.join(".", arch)
+  if not os.path.isdir(archdir):
+    sys.stderr.write("Architecture directory not available \"%s\", so not attempting kextractlinux.\n" % (archdir))
+    exit(2)
   args.extend([ "-e", "ARCH=%s" % (arch), "-e", "SRCARCH=%s" % (srcarch), "-e", "KERNELVERSION=kcu", "-e", "srctree=./", "-e", "CC=cc", "-e", "LD=ld", "-e", "RUSTC=rustc" ])
   # set arch-specific environment variables
   args.extend(arch_specific(arch))


### PR DESCRIPTION
Tell the user and raise an ArchitectureUnavailableError exception if the requested architecture is not available in the selected version of the Linux kernel.

Fixes #160 