### PR TITLE
adapt kismet to run for older linux kernel versions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,3 +29,5 @@ include kextractors/kextractor-4.18/preprocess.c
 include kextractors/kextractor-4.18/symbol.c
 include kextractors/kextractor-4.18/util.c
 include kextractors/kextractor-4.18/zconf.lex.c
+
+recursive-include kmax/resources *

--- a/kextractors/kextractor-3.19/kextractor.c
+++ b/kextractors/kextractor-3.19/kextractor.c
@@ -2045,19 +2045,6 @@ int main(int argc, char **argv)
         }
         fprintf(output_fp, "|(");
 
-        // for formatting
-        int printed_expr = 0;
-
-        // TODO: issue with the visible_expr, dir_dep.expr, and rev_dep.expr of choices
-        // The content of visible, direct dependency, and reverse dependency expressions are strange for choices:
-        // Seems like direct dependency expression is always NULL.
-        // visib_expr == NULL && rev_dep_expr != NULL -> rev_dep_expr == 1
-        // visib_expr != NULL && rev_dep_expr == NULL -> valid constraint in visib_expr. Example: check for CONFIG_USB_ZERO.
-        // visib_expr != NULL && rev_dep_expr != NULL -> they are the same most of the time except a few cases. Example: check for CONFIG_VMSPLIT_3G.
-        // In conclusion, I (Necip) cannot deduce what leads to those different behaviours looking at the specific examples.
-        // To understand, we need to have a deeper analysis on how Kconfig parser processes choice symbols.
-        // Until then, let's have the conjunction of all to ensure we have valid (yet more in complex/repetitive form than needed) results.
-	
 	// Both depends on and visibility shoul be satisfied for 
 	// the choice to be selectable.
 	// Kconfig conjuncts depends on constraint to the 
@@ -2069,20 +2056,26 @@ int main(int argc, char **argv)
 	// 'm' which is currently not needed for kclause.
 	// In sum, only visibility is needed as the condition of
 	// choice.
-        
+
+        // for formatting
+        int printed_expr = 0;
 	prop = NULL;
         for_all_prompts(sym, prop) {
           if ((NULL != prop)) {
-	    // commented code below can handle the case where multiple
-	    // prompts are defined, where satisfying any of them makes
-	    // the config option visible. However, multiple prompts 
-	    // raises a warning by Kconfig and we consider it as an 
-	    // invalid use of Kconfig language. Thus, this code is 
-	    // commented for now. Note that, using this code here
-	    // means the code for prompt keyword should also reflect
-	    // this case.
-	    //if (printed_expr)
-	    //  fprintf(output_fp, " or ");
+
+	    if (printed_expr) {
+        fprintf(stderr, "warning: encountered multiple prompts, ignoring.");
+        break;
+        // commented code below can handle the case where multiple
+	      // prompts are defined, where satisfying any of them makes
+	      // the config option visible. However, multiple prompts 
+        // raises a warning by Kconfig and we consider it as an 
+        // invalid use of Kconfig language. Thus, this code is 
+        // commented for now. Note that, using this code here
+        // means the code for prompt keyword should also reflect
+        // this case.
+	      //fprintf(output_fp, " or ");
+      }
 	    
 	    printed_expr = 1;
 	    fprintf(output_fp, "(");
@@ -2094,37 +2087,6 @@ int main(int argc, char **argv)
             fprintf(output_fp, ")");
           }
         }
- 
-	// below code for visible is not correct as the prop came
-	// from sym_get_choice_prop, which returns the choice values
-	// that this choice has.
-	
-	// visible
-        //if (prop->visible.expr) {
-        //  if (printed_expr) fprintf(output_fp, " and ");
-        //  printed_expr = 1;
-        //  fprintf(output_fp, "(");
-        //  print_python_expr(prop->visible.expr, output_fp, E_NONE);
-        //  fprintf(output_fp, ")");
-        //}
-
-        // direct dependency
-        //if (sym->dir_dep.expr) {
-        //  if (printed_expr) fprintf(output_fp, " and ");
-        //  printed_expr = 1;
-        //  fprintf(output_fp, "(");
-        //  print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
-        //  fprintf(output_fp, ")");
-        //}
-
-        // reverse dependency
-        //if (sym->rev_dep.expr) {
-        //  if (printed_expr) fprintf(output_fp, " and ");
-        //  printed_expr = 1;
-        //  fprintf(output_fp, "(");
-        //  print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
-        //  fprintf(output_fp, ")");
-        //}
 
         if (!printed_expr)
           fprintf(output_fp, "1");

--- a/kextractors/kextractor-3.19/kextractor.c
+++ b/kextractors/kextractor-3.19/kextractor.c
@@ -2064,18 +2064,18 @@ int main(int argc, char **argv)
           if ((NULL != prop)) {
 
 	    if (printed_expr) {
-        fprintf(stderr, "warning: encountered multiple prompts, ignoring.");
-        break;
-        // commented code below can handle the case where multiple
+	      fprintf(stderr, "warning: encountered multiple prompts, ignoring.");
+	      break;
+	      // commented code below can handle the case where multiple
 	      // prompts are defined, where satisfying any of them makes
 	      // the config option visible. However, multiple prompts 
-        // raises a warning by Kconfig and we consider it as an 
-        // invalid use of Kconfig language. Thus, this code is 
-        // commented for now. Note that, using this code here
-        // means the code for prompt keyword should also reflect
-        // this case.
+	      // raises a warning by Kconfig and we consider it as an 
+	      // invalid use of Kconfig language. Thus, this code is 
+              // commented for now. Note that, using this code here
+              // means the code for prompt keyword should also reflect
+              // this case.
 	      //fprintf(output_fp, " or ");
-      }
+	    }
 	    
 	    printed_expr = 1;
 	    fprintf(output_fp, "(");

--- a/kextractors/kextractor-3.19/kextractor.c
+++ b/kextractors/kextractor-3.19/kextractor.c
@@ -2026,13 +2026,14 @@ int main(int argc, char **argv)
         struct expr *e;
 
         prop = sym_get_choice_prop(sym);
-
-        switch(sym->type) {
+	
+	// print choice type, depending on config type and optional statement
+	switch(sym->type) {
           case S_BOOLEAN:
-            fprintf(output_fp, "bool_choice");
+            sym_is_optional(sym) ? fprintf(output_fp, "bool_opt_choice") : fprintf(output_fp, "bool_choice");
             break;
           case S_TRISTATE:
-            fprintf(output_fp, "tristate_choice");
+            sym_is_optional(sym) ? fprintf(output_fp, "tristate_opt_choice") : fprintf(output_fp, "tristate_choice");
             break;
           default:
             fprintf(stderr, "fatal: choice type can only be bool or tristate, otherwise is impossible due to the parser.\n");

--- a/kextractors/kextractor-3.19/kextractor.c
+++ b/kextractors/kextractor-3.19/kextractor.c
@@ -2057,33 +2057,74 @@ int main(int argc, char **argv)
         // In conclusion, I (Necip) cannot deduce what leads to those different behaviours looking at the specific examples.
         // To understand, we need to have a deeper analysis on how Kconfig parser processes choice symbols.
         // Until then, let's have the conjunction of all to ensure we have valid (yet more in complex/repetitive form than needed) results.
-
-        // visible
-        if (prop->visible.expr) {
-          if (printed_expr) fprintf(output_fp, " and ");
-          printed_expr = 1;
-          fprintf(output_fp, "(");
-          print_python_expr(prop->visible.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
+	
+	// Both depends on and visibility shoul be satisfied for 
+	// the choice to be selectable.
+	// Kconfig conjuncts depends on constraint to the 
+	// visibility constraint, so that for choice, looking at
+	// only the visibility is sufficient.
+	// rev_dep of choice copies the visibility to prevent
+	// non-optional choices have no selection (menu.c, l854) 
+	// Thus, rev_dep is the same as visibiltiy except conjoing
+	// 'm' which is currently not needed for kclause.
+	// In sum, only visibility is needed as the condition of
+	// choice.
+        
+	prop = NULL;
+        for_all_prompts(sym, prop) {
+          if ((NULL != prop)) {
+	    // commented code below can handle the case where multiple
+	    // prompts are defined, where satisfying any of them makes
+	    // the config option visible. However, multiple prompts 
+	    // raises a warning by Kconfig and we consider it as an 
+	    // invalid use of Kconfig language. Thus, this code is 
+	    // commented for now. Note that, using this code here
+	    // means the code for prompt keyword should also reflect
+	    // this case.
+	    //if (printed_expr)
+	    //  fprintf(output_fp, " or ");
+	    
+	    printed_expr = 1;
+	    fprintf(output_fp, "(");
+            if (NULL != prop->visible.expr) {
+              print_python_expr(prop->visible.expr, output_fp, E_NONE);
+            } else {
+              fprintf(output_fp, "1");
+            }
+            fprintf(output_fp, ")");
+          }
         }
+ 
+	// below code for visible is not correct as the prop came
+	// from sym_get_choice_prop, which returns the choice values
+	// that this choice has.
+	
+	// visible
+        //if (prop->visible.expr) {
+        //  if (printed_expr) fprintf(output_fp, " and ");
+        //  printed_expr = 1;
+        //  fprintf(output_fp, "(");
+        //  print_python_expr(prop->visible.expr, output_fp, E_NONE);
+        //  fprintf(output_fp, ")");
+        //}
 
         // direct dependency
-        if (sym->dir_dep.expr) {
-          if (printed_expr) fprintf(output_fp, " and ");
-          printed_expr = 1;
-          fprintf(output_fp, "(");
-          print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
-        }
+        //if (sym->dir_dep.expr) {
+        //  if (printed_expr) fprintf(output_fp, " and ");
+        //  printed_expr = 1;
+        //  fprintf(output_fp, "(");
+        //  print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
+        //  fprintf(output_fp, ")");
+        //}
 
         // reverse dependency
-        if (sym->rev_dep.expr) {
-          if (printed_expr) fprintf(output_fp, " and ");
-          printed_expr = 1;
-          fprintf(output_fp, "(");
-          print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
-        }
+        //if (sym->rev_dep.expr) {
+        //  if (printed_expr) fprintf(output_fp, " and ");
+        //  printed_expr = 1;
+        //  fprintf(output_fp, "(");
+        //  print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
+        //  fprintf(output_fp, ")");
+        //}
 
         if (!printed_expr)
           fprintf(output_fp, "1");

--- a/kextractors/kextractor-3.19/kextractor.c
+++ b/kextractors/kextractor-3.19/kextractor.c
@@ -2034,6 +2034,9 @@ int main(int argc, char **argv)
           case S_TRISTATE:
             fprintf(output_fp, "tristate_choice");
             break;
+          default:
+            fprintf(stderr, "fatal: choice type can only be bool or tristate, otherwise is impossible due to the parser.\n");
+            exit(1);
         }
 
         expr_list_for_each_sym(prop->expr, e, def_sym) {

--- a/kextractors/kextractor-4.12.8/kextractor.c
+++ b/kextractors/kextractor-4.12.8/kextractor.c
@@ -2054,6 +2054,9 @@ int main(int argc, char **argv)
           case S_TRISTATE:
             fprintf(output_fp, "tristate_choice");
             break;
+          default:
+            fprintf(stderr, "fatal: choice type can only be bool or tristate, otherwise is impossible due to the parser.\n");
+            exit(1);
         }
 
         expr_list_for_each_sym(prop->expr, e, def_sym) {

--- a/kextractors/kextractor-4.12.8/kextractor.c
+++ b/kextractors/kextractor-4.12.8/kextractor.c
@@ -2046,13 +2046,14 @@ int main(int argc, char **argv)
         struct expr *e;
 
         prop = sym_get_choice_prop(sym);
-
-        switch(sym->type) {
+	
+	// print choice type, depending on config type and optional statement
+	switch(sym->type) {
           case S_BOOLEAN:
-            fprintf(output_fp, "bool_choice");
+            sym_is_optional(sym) ? fprintf(output_fp, "bool_opt_choice") : fprintf(output_fp, "bool_choice");
             break;
           case S_TRISTATE:
-            fprintf(output_fp, "tristate_choice");
+            sym_is_optional(sym) ? fprintf(output_fp, "tristate_opt_choice") : fprintf(output_fp, "tristate_choice");
             break;
           default:
             fprintf(stderr, "fatal: choice type can only be bool or tristate, otherwise is impossible due to the parser.\n");

--- a/kextractors/kextractor-4.12.8/kextractor.c
+++ b/kextractors/kextractor-4.12.8/kextractor.c
@@ -2084,18 +2084,18 @@ int main(int argc, char **argv)
           if ((NULL != prop)) {
 
 	    if (printed_expr) {
-        fprintf(stderr, "warning: encountered multiple prompts, ignoring.");
-        break;
-        // commented code below can handle the case where multiple
+	      fprintf(stderr, "warning: encountered multiple prompts, ignoring.");
+	      break;
+	      // commented code below can handle the case where multiple
 	      // prompts are defined, where satisfying any of them makes
 	      // the config option visible. However, multiple prompts 
-        // raises a warning by Kconfig and we consider it as an 
-        // invalid use of Kconfig language. Thus, this code is 
-        // commented for now. Note that, using this code here
-        // means the code for prompt keyword should also reflect
-        // this case.
+	      // raises a warning by Kconfig and we consider it as an 
+	      // invalid use of Kconfig language. Thus, this code is 
+              // commented for now. Note that, using this code here
+              // means the code for prompt keyword should also reflect
+              // this case.
 	      //fprintf(output_fp, " or ");
-      }
+	    }
 	    
 	    printed_expr = 1;
 	    fprintf(output_fp, "(");

--- a/kextractors/kextractor-4.12.8/kextractor.c
+++ b/kextractors/kextractor-4.12.8/kextractor.c
@@ -2077,33 +2077,74 @@ int main(int argc, char **argv)
         // In conclusion, I (Necip) cannot deduce what leads to those different behaviours looking at the specific examples.
         // To understand, we need to have a deeper analysis on how Kconfig parser processes choice symbols.
         // Until then, let's have the conjunction of all to ensure we have valid (yet more in complex/repetitive form than needed) results.
-
-        // visible
-        if (prop->visible.expr) {
-          if (printed_expr) fprintf(output_fp, " and ");
-          printed_expr = 1;
-          fprintf(output_fp, "(");
-          print_python_expr(prop->visible.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
+	
+	// Both depends on and visibility shoul be satisfied for 
+	// the choice to be selectable.
+	// Kconfig conjuncts depends on constraint to the 
+	// visibility constraint, so that for choice, looking at
+	// only the visibility is sufficient.
+	// rev_dep of choice copies the visibility to prevent
+	// non-optional choices have no selection (menu.c, l854) 
+	// Thus, rev_dep is the same as visibiltiy except conjoing
+	// 'm' which is currently not needed for kclause.
+	// In sum, only visibility is needed as the condition of
+	// choice.
+        
+	prop = NULL;
+        for_all_prompts(sym, prop) {
+          if ((NULL != prop)) {
+	    // commented code below can handle the case where multiple
+	    // prompts are defined, where satisfying any of them makes
+	    // the config option visible. However, multiple prompts 
+	    // raises a warning by Kconfig and we consider it as an 
+	    // invalid use of Kconfig language. Thus, this code is 
+	    // commented for now. Note that, using this code here
+	    // means the code for prompt keyword should also reflect
+	    // this case.
+	    //if (printed_expr)
+	    //  fprintf(output_fp, " or ");
+	    
+	    printed_expr = 1;
+	    fprintf(output_fp, "(");
+            if (NULL != prop->visible.expr) {
+              print_python_expr(prop->visible.expr, output_fp, E_NONE);
+            } else {
+              fprintf(output_fp, "1");
+            }
+            fprintf(output_fp, ")");
+          }
         }
+ 
+	// below code for visible is not correct as the prop came
+	// from sym_get_choice_prop, which returns the choice values
+	// that this choice has.
+	
+	// visible
+        //if (prop->visible.expr) {
+        //  if (printed_expr) fprintf(output_fp, " and ");
+        //  printed_expr = 1;
+        //  fprintf(output_fp, "(");
+        //  print_python_expr(prop->visible.expr, output_fp, E_NONE);
+        //  fprintf(output_fp, ")");
+        //}
 
         // direct dependency
-        if (sym->dir_dep.expr) {
-          if (printed_expr) fprintf(output_fp, " and ");
-          printed_expr = 1;
-          fprintf(output_fp, "(");
-          print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
-        }
+        //if (sym->dir_dep.expr) {
+        //  if (printed_expr) fprintf(output_fp, " and ");
+        //  printed_expr = 1;
+        //  fprintf(output_fp, "(");
+        //  print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
+        //  fprintf(output_fp, ")");
+        //}
 
         // reverse dependency
-        if (sym->rev_dep.expr) {
-          if (printed_expr) fprintf(output_fp, " and ");
-          printed_expr = 1;
-          fprintf(output_fp, "(");
-          print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
-          fprintf(output_fp, ")");
-        }
+        //if (sym->rev_dep.expr) {
+        //  if (printed_expr) fprintf(output_fp, " and ");
+        //  printed_expr = 1;
+        //  fprintf(output_fp, "(");
+        //  print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
+        //  fprintf(output_fp, ")");
+        //}
 
         if (!printed_expr)
           fprintf(output_fp, "1");

--- a/kextractors/kextractor-4.12.8/kextractor.c
+++ b/kextractors/kextractor-4.12.8/kextractor.c
@@ -2014,36 +2014,97 @@ int main(int argc, char **argv)
     /*   } */
     /* } */
 
+    // for choice symbols, add choice's visibility and dependency conditions to config_vars' direct dependency
+    // This is disabled because kclause already accounts for this dependency by adding the implication
+    // clause of "implication(possible_choices, dep_expr)". This is saying that possible_choices cannot
+    // be enabled without having dep_expr enabled.
+    // for_all_symbols(i, sym) {
+    //   if (sym_is_choice(sym)) {
+    //     struct expr *e;
+    //     struct symbol *def_sym;
+    //     struct property* prop = sym_get_choice_prop(sym);
+
+    //     if (prop && prop->visible.expr) {
+    //       expr_list_for_each_sym(prop->expr, e, def_sym) {
+    //         if (!def_sym->dir_dep.expr) {
+    //           // use the visibility expression
+    //           def_sym->dir_dep.expr = expr_copy(prop->visible.expr);
+    //         } else {
+    //           // conjuct the direct dependency with the visibility condition of the <choice>
+    //           def_sym->dir_dep.expr = expr_alloc_and(def_sym->dir_dep.expr, prop->visible.expr);
+    //         }
+    //       }
+    //     }
+    //   }
+    // }
     // print all dependent config vars
     for_all_symbols(i, sym) {
       // TODO: deal with choice nodes
-      if (sym_is_choice(sym) && sym->type == S_BOOLEAN) {
+      if (sym_is_choice(sym)) {
         struct property *prop;
         struct symbol *def_sym;
         struct expr *e;
 
         prop = sym_get_choice_prop(sym);
 
-        fprintf(output_fp, "bool_choice");
+        switch(sym->type) {
+          case S_BOOLEAN:
+            fprintf(output_fp, "bool_choice");
+            break;
+          case S_TRISTATE:
+            fprintf(output_fp, "tristate_choice");
+            break;
+        }
+
         expr_list_for_each_sym(prop->expr, e, def_sym) {
           fprintf(output_fp, " %s%s", config_prefix, def_sym->name);  // any dependencies should be handled below with 'dep'
         }
         fprintf(output_fp, "|(");
-        if ((NULL != sym->dir_dep.expr) && (NULL != sym->rev_dep.expr)) {
+
+        // for formatting
+        int printed_expr = 0;
+
+        // TODO: issue with the visible_expr, dir_dep.expr, and rev_dep.expr of choices
+        // The content of visible, direct dependency, and reverse dependency expressions are strange for choices:
+        // Seems like direct dependency expression is always NULL.
+        // visib_expr == NULL && rev_dep_expr != NULL -> rev_dep_expr == 1
+        // visib_expr != NULL && rev_dep_expr == NULL -> valid constraint in visib_expr. Example: check for CONFIG_USB_ZERO.
+        // visib_expr != NULL && rev_dep_expr != NULL -> they are the same most of the time except a few cases. Example: check for CONFIG_VMSPLIT_3G.
+        // In conclusion, I (Necip) cannot deduce what leads to those different behaviours looking at the specific examples.
+        // To understand, we need to have a deeper analysis on how Kconfig parser processes choice symbols.
+        // Until then, let's have the conjunction of all to ensure we have valid (yet more in complex/repetitive form than needed) results.
+
+        // visible
+        if (prop->visible.expr) {
+          if (printed_expr) fprintf(output_fp, " and ");
+          printed_expr = 1;
+          fprintf(output_fp, "(");
+          print_python_expr(prop->visible.expr, output_fp, E_NONE);
+          fprintf(output_fp, ")");
+        }
+
+        // direct dependency
+        if (sym->dir_dep.expr) {
+          if (printed_expr) fprintf(output_fp, " and ");
+          printed_expr = 1;
           fprintf(output_fp, "(");
           print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
-          fprintf(output_fp, ") and (");
+          fprintf(output_fp, ")");
+        }
+
+        // reverse dependency
+        if (sym->rev_dep.expr) {
+          if (printed_expr) fprintf(output_fp, " and ");
+          printed_expr = 1;
+          fprintf(output_fp, "(");
           print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
           fprintf(output_fp, ")");
-        } else if (NULL != sym->dir_dep.expr) {
-          print_python_expr(sym->dir_dep.expr, output_fp, E_NONE);
-        } else if (NULL != sym->rev_dep.expr) {
-          print_python_expr(sym->rev_dep.expr, output_fp, E_NONE);
-        } else {
-          fprintf(output_fp, "1");
         }
-        fprintf(output_fp, ")");
-        fprintf(output_fp, "\n");
+
+        if (!printed_expr)
+          fprintf(output_fp, "1");
+        
+        fprintf(output_fp, ")\n");
       }
       
       if (!sym->name || strlen(sym->name) == 0)

--- a/kmax/kismet
+++ b/kmax/kismet
@@ -9,8 +9,8 @@ import sys
 import datetime
 from kmax.klocalizer import Klocalizer
 from kmax.arch import Arch
-from kmax.udd_warning_parser import parse_warnings
 from kmax.vcommon import get_build_system_id
+from kmax import udd_warning_parser
 import logging
 import subprocess
 import csv
@@ -61,6 +61,10 @@ def warning(msg, ending="\n"):
 
 def error(msg, ending="\n"):
   sys.stderr.write("ERROR: %s%s" % (msg, ending))
+
+def debug(msg, enabled, ending="\n"):
+  if enabled:
+    sys.stderr.write("DEBUG: %s%s" % (msg, ending))
 
 # model might be the shortcut solution, e.g., the sat model for Or(A,B,C)
 # might be just A. Get a complete model the input model.
@@ -318,6 +322,9 @@ if __name__ == '__main__':
   argparser.add_argument('--allow-config-broken',
                         action="store_true",
                         help="""Allow CONFIG_BROKEN dependencies.  """)
+  argparser.add_argument('--verbose',
+                        action="store_true",
+                        help="""Verbose mode prints additional messages to stderr.""")
   
   args = argparser.parse_args()
   arch_name = args.arch
@@ -343,6 +350,7 @@ if __name__ == '__main__':
   summary_txt_path = args.summary_txt if args.summary_txt != None else "kismet_summary_%s.txt" % arch_name
   summary_use_testcase_realpath= args.use_fullpath_in_summary
   disable_config_broken = not args.allow_config_broken
+  verbose = args.verbose
 
   if not precise_SAT_pass:
     if generate_sample:
@@ -802,6 +810,7 @@ if __name__ == '__main__':
     selectee and selector assumed to have CONFIG_ prefix.
     """
     assert os.path.isfile(cfgfilepath)
+    debug("Verifying the alarm for (%s,%s) with config file %s (arch=%s)" % (selectee, selector, cfgfilepath, arch_name), verbose)
 
     # use a copy so the original won't change
     kismetcopy_path = "kismet_verifcopy_" + os.path.basename(cfgfilepath)
@@ -810,11 +819,13 @@ if __name__ == '__main__':
 
     command = ["make", "ARCH=%s" % arch_name, "KCONFIG_CONFIG=%s" % os.path.realpath(kismets_copy), "olddefconfig"]
     popen = subprocess.Popen(command, stdin=DEVNULL, stdout=DEVNULL, stderr=subprocess.PIPE, cwd=linux_ksrc)
-    stderr = popen.communicate()[1].decode("utf-8")
-    parsed_warnings = parse_warnings(str(stderr))
+    make_stderr = str(popen.communicate()[1].decode("utf-8"))
+    debug("Kconfig output is: \"%s\"" % make_stderr, verbose)
+    parsed_warnings = udd_warning_parser.parse_warnings(make_stderr)
     rm_cfg_prefix = lambda text: text[text.startswith("CONFIG_") and len("CONFIG_"):]
     nocfg_selector, nocfg_selectee = rm_cfg_prefix(selector), rm_cfg_prefix(selectee)
     verified = nocfg_selectee in parsed_warnings and nocfg_selector in parsed_warnings[nocfg_selectee]
+    debug("Verification result: %s" % verified, verbose)
 
     # remove the copy
     os.remove(kismets_copy)
@@ -827,7 +838,27 @@ if __name__ == '__main__':
     current_time = datetime.datetime.now().strftime("%H:%M:%S")
     info("%s Verification from test cases progress: %s." % (current_time, dumps_progress(num_checked, count_testcasgen_configscreated)), ending="\r")
 
+  kconfig_ready_for_verification = False
+  kconfig_extension_applied = False
   if verify:
+    # If needed, apply the Kconfig extension patch, which modifies Kconfig
+    # code to print unmet direct dependency warnings in explicit format
+    # that is amenable to use in verification.
+    kconfig_extension_needed = not udd_warning_parser.does_kconfig_print_uddwarning_in_explicit_format(linux_ksrc)
+    if not kconfig_extension_needed:
+      debug("Kconfig is ready for verification without extension patch.", verbose)
+      kconfig_ready_for_verification = True
+      kconfig_extension_applied = False
+    else: #< Kconfig extension is needed.
+      debug("Kconfig extension is needed for verification: applying the patch.", verbose)
+      ret = udd_warning_parser.patch_kconfig_udd_printer_extension(linux_ksrc)
+      debug("Kconfig extension patch success result: %s" % ret, verbose)
+      kconfig_ready_for_verification = ret
+      kconfig_extension_applied = ret
+      if not ret:
+        error("Failed to apply Kconfig verification patch: kismet will skip verification.")
+
+  if verify and kconfig_ready_for_verification:
     num_verified = 0
     unique_verified = 0
     some_testcase_verifies = 0 # the count of constructs with alarms that at least one related test case verifies the alarm
@@ -894,6 +925,15 @@ if __name__ == '__main__':
     info_str += " For %d constructs, test cases had contradictory results." % (count_verification_some_verified_per_unique_construct - count_verification_all_verified_per_unique_construct)
     info_str += " For %d constructs, no test case verified the alarm." % (count_testcasgen_configscreated - count_verification_some_verified_per_unique_construct)
     info(info_str)
+
+  # If applied, reverse the kconfig extension.
+  if kconfig_extension_applied:
+    debug("Reversing the Kconfig extension patch that was applied for verification.", verbose)
+    ret = udd_warning_parser.reverse_patch_kconfig_udd_printer_extension(linux_ksrc)
+    if ret:
+      debug("Reversing the Kconfig extension patch was successful.", verbose)
+    else:
+      warning("Failed to reverse the Kconfig extension patch: the Linux source is left modified.")
 
   #
   # Dump summary txt

--- a/kmax/resources/kismet_udd_printer_extension.h
+++ b/kmax/resources/kismet_udd_printer_extension.h
@@ -1,0 +1,102 @@
+/**
+ * This is an extension to Kconfig code to print unmet dependency warnings
+ * in an explicit format amenable to bug verification by kismet.
+ * 
+ * The code was adapted from the Kconfig code of newer Linux kernel
+ * versions. Function names are prefixed with "kismet_" to avoid potential
+ * name collisions.
+ * */
+
+#ifndef KISMET_UDD_PRINTER_EXTENSION_H
+#define KISMET_UDD_PRINTER_EXTENSION_H
+
+#include <string.h>
+
+#include "lkc.h"
+
+void expr_gstr_print(struct expr*, struct gstr*); // expr.c
+tristate expr_calc_value(struct expr*); // expr.c
+
+/*
+ * Transform the top level "||" tokens into newlines and prepend each
+ * line with a minus. This makes expressions much easier to read.
+ * Suitable for reverse dependency expressions.
+ */
+static void kismet_expr_print_revdep(struct expr *e,
+			      void (*fn)(void *, struct symbol *, const char *),
+			      void *data, tristate pr_type, const char **title)
+{
+	if (e->type == E_OR) {
+		kismet_expr_print_revdep(e->left.expr, fn, data, pr_type, title);
+		kismet_expr_print_revdep(e->right.expr, fn, data, pr_type, title);
+	} else if (expr_calc_value(e) == pr_type) {
+		if (*title) {
+			fn(data, NULL, *title);
+			*title = NULL;
+		}
+
+		fn(data, NULL, "  - ");
+		expr_print(e, fn, data, E_NONE);
+		fn(data, NULL, "\n");
+	}
+}
+
+static void kismet_expr_print_gstr_helper(void *data, struct symbol *sym, const char *str)
+{
+	struct gstr *gs = (struct gstr*)data;
+	const char *sym_str = NULL;
+
+	if (sym)
+		sym_str = sym_get_string_value(sym);
+
+	if (gs->max_width) {
+		unsigned extra_length = strlen(str);
+		const char *last_cr = strrchr(gs->s, '\n');
+		unsigned last_line_length;
+
+		if (sym_str)
+			extra_length += 4 + strlen(sym_str);
+
+		if (!last_cr)
+			last_cr = gs->s;
+
+		last_line_length = strlen(gs->s) - (last_cr - gs->s);
+
+		if ((last_line_length + extra_length) > gs->max_width)
+			str_append(gs, "\\\n");
+	}
+
+	str_append(gs, str);
+	if (sym && sym->type != S_UNKNOWN)
+		str_printf(gs, " [=%s]", sym_str);
+}
+
+static void kismet_expr_gstr_print_revdep(struct expr *e, struct gstr *gs,
+			    tristate pr_type, const char *title)
+{
+	kismet_expr_print_revdep(e, kismet_expr_print_gstr_helper, gs, pr_type, &title);
+}
+
+
+static void kismet_sym_warn_unmet_dep(struct symbol *sym)
+{
+	struct gstr gs = str_new();
+
+	str_printf(&gs,
+		   "\nWARNING: unmet direct dependencies detected for %s\n",
+		   sym->name);
+	str_printf(&gs,
+		   "  Depends on [%c]: ",
+		   sym->dir_dep.tri == mod ? 'm' : 'n');
+	expr_gstr_print(sym->dir_dep.expr, &gs);
+	str_printf(&gs, "\n");
+
+	kismet_expr_gstr_print_revdep(sym->rev_dep.expr, &gs, yes,
+			       "  Selected by [y]:\n");
+	kismet_expr_gstr_print_revdep(sym->rev_dep.expr, &gs, mod,
+			       "  Selected by [m]:\n");
+
+	fputs(str_get(&gs), stderr);
+}
+
+#endif // KISMET_UDD_PRINTER_EXTENSION_H

--- a/kmax/resources/kismet_verification_patch.diff
+++ b/kmax/resources/kismet_verification_patch.diff
@@ -1,0 +1,11 @@
+diff --git a/scripts/kconfig/symbol.c b/scripts/kconfig/symbol.c
+index 2220bc4b051b..c10911a11b36 100644
+--- a/scripts/kconfig/symbol.c
++++ b/scripts/kconfig/symbol.c
+@@ -12,1 +12,2 @@
+ #include "lkc.h"
++#include "kismet_udd_printer_extension.h"
+@@ -415,1 +416,3 @@ void sym_calc_value(struct symbol *sym)
+ 		calc_newval:
++			if (sym->dir_dep.tri < sym->rev_dep.tri)
++				kismet_sym_warn_unmet_dep(sym);

--- a/kmax/udd_warning_parser.py
+++ b/kmax/udd_warning_parser.py
@@ -1,5 +1,73 @@
 # unmet direct dependency warnings parser
-import os, re, pprint, textwrap, argparse
+import os, re
+from shutil import which, copyfile
+from kmax.vcommon import run
+
+def __get_installed_module_path() -> str:
+    import sys
+    return os.path.dirname(sys.modules['kmax'].__file__)
+
+def __get_resource_path(r_relpath) -> str:
+    mpath = __get_installed_module_path()
+    return os.path.join(mpath, r_relpath)
+
+def patch_kconfig_udd_printer_extension(linux_ksrc: str) -> bool:
+    """Patch Kconfig code to print explicit unmet direct dependency bug
+    warnings.
+    """
+    assert which("patch")
+    
+    # Apply the patch.
+    pfile = __get_resource_path("resources/kismet_verification_patch.diff")
+    assert os.path.isfile(pfile)
+    target_file = os.path.join(linux_ksrc, "scripts/kconfig/symbol.c")
+    assert os.path.isfile(target_file)
+    patch_cmd = "patch -p1 %s < %s" % (target_file, pfile)
+    _, _, patch_retcode, _ = run(patch_cmd, shell=True)
+
+    # Copy the extension header file.
+    src = __get_resource_path("resources/kismet_udd_printer_extension.h")
+    assert os.path.isfile(src)
+    dst_extfile = os.path.join(linux_ksrc, "scripts/kconfig/kismet_udd_printer_extension.h")
+    copyfile(src, dst_extfile)
+    assert os.path.isfile(dst_extfile)
+
+    return patch_retcode == 0 and os.path.isfile(dst_extfile)
+
+def reverse_patch_kconfig_udd_printer_extension(linux_ksrc: str) -> bool:
+    """Reverse the patch to the Kconfig code that prints explicit unmet
+    direct dependency bug warnings.
+    """
+    assert which("patch")
+    
+    # Reverse the patch.
+    pfile = __get_resource_path("resources/kismet_verification_patch.diff")
+    assert os.path.isfile(pfile)
+    target_file = os.path.join(linux_ksrc, "scripts/kconfig/symbol.c")
+    assert os.path.isfile(target_file)
+    patch_cmd = "patch -R -p1 %s < %s" % (target_file, pfile)
+    _, _, patch_retcode, _ = run(patch_cmd, shell=True)
+
+    # Remove the extension header file.
+    extfile = os.path.join(linux_ksrc, "scripts/kconfig/kismet_udd_printer_extension.h")
+    if os.path.isfile(extfile):
+        os.remove(extfile)
+
+    return patch_retcode == 0 and not os.path.exists(extfile)
+
+def does_kconfig_print_uddwarning_in_explicit_format(linux_ksrc) -> bool:
+    """Returns whether Kconfig has code for printing unmet direct
+    dependency warnings in an explicit format that is amenable to use in
+    verifying bugs with test cases.
+
+    The explicit format starts with:
+        "WARNING: unmet direct dependencies detected for"
+    """
+    assert which("grep")
+    kconfig_scripts_path = os.path.join(linux_ksrc, "scripts/kconfig/")
+    cmd = "grep -rI \"WARNING: unmet direct dependencies detected for\""
+    _, _, retcode, _ = run(cmd, cwd = kconfig_scripts_path, shell = True)
+    return retcode == 0
 
 # given the content of the make output possibly including multiple warnings
 # parses the content and returns {selected: {selecters} }

--- a/kmax/udd_warning_parser.py
+++ b/kmax/udd_warning_parser.py
@@ -1,9 +1,40 @@
 # unmet direct dependency warnings parser
-import os, re, pprint, textwrap, argparse
+import re
+
+def parse_warnings(make_output: str) -> dict:
+    """Parse and return the unmet direct dependency warnings from make
+    output (make olddefconfig).
+
+    Returns a dict that maps selectees to list of selectors.
+
+    The unmet direct dependency warning message format was changed with
+    the Linux kernel commit f8f69dc0b4e0. This method can parse for both
+    formats. However, the method asserts that a single format is used in
+    a given make output.
+    """
+    new_format_ret = parse_warnings_newformat(make_output)
+    old_format_ret = parse_warnings_oldformat(make_output)
+
+    # Can't have warnings in both formats in a make output.
+    assert not (len(new_format_ret) > 0 and len(old_format_ret) > 0)
+
+    if new_format_ret:
+        return new_format_ret
+    elif old_format_ret:
+        return old_format_ret
+    else:
+        return {} #< no unmet dependency warnings.
+
+
+###########################################################################
+# NEW FORMAT PARSER (after the linux kernel commit f8f69dc0b4e0) ##########
+###########################################################################
 
 # given the content of the make output possibly including multiple warnings
 # parses the content and returns {selected: {selecters} }
-def parse_warnings(make_output):
+def parse_warnings_newformat(make_output):
+    """Format: after the Linux kernel commit f8f69dc0b4e0
+    """
     selected_prefix = r"WARNING: unmet direct dependencies detected for "
     selected_suffix = r"\n"
     selected_re = selected_prefix + "(.*?)" + selected_suffix
@@ -14,12 +45,14 @@ def parse_warnings(make_output):
     for i in range(len(warning_start_indices) - 1):
         warning_str_ranges.append( (warning_start_indices[i], warning_start_indices[i+1]) )
 
-    res = [ process_warning(make_output[s:e]) for s,e in warning_str_ranges ]
+    res = [ process_warning_newformat(make_output[s:e]) for s,e in warning_str_ranges ]
 
     return dict( (selected, selecters) for selected, _, selecters in res )
 
 # processes the first warning encountered. used as helper to parse_warnings()
-def process_warning(warning_str):
+def process_warning_newformat(warning_str):
+    """Format: after the Linux kernel commit f8f69dc0b4e0
+    """
     # get the selected
     selected_prefix = r"WARNING: unmet direct dependencies detected for "
     selected_suffix = r"\n"
@@ -40,3 +73,139 @@ def process_warning(warning_str):
     selecters = set([m.group(1).strip() for m in re.finditer(selecter_re, warning_str)])
 
     return selected, dependson, selecters
+
+###########################################################################
+# OLD FORMAT PARSER (before the linux kernel commit f8f69dc0b4e0) ########
+###########################################################################
+
+def get_all_terms_of_bool_expr(expr):
+  """Given a string boolean expression, return all the terms in the order
+  they appear. in the expression.
+
+  Expected format: starts with "(" and ends with ")"
+
+  Example input/output:
+  "(A && B)" returns ["A", "B"]
+  "(A)" returns "A"
+  """
+  # starts with "(", ends with ")", non-empty content
+  assert expr
+  assert len(expr) > 2
+  assert expr[0] == "("
+  assert expr[-1] == ")"
+
+  r = "[\( ]([a-zA-Z0-9_]*)[ \)]"
+  match_results = re.findall(r, expr)
+  assert match_results
+  return match_results
+
+def process_warning_oldformat(warning_str):
+  """Format: before the Linux kernel commit f8f69dc0b4e0
+  
+  Given a single line of unmet direct dependency warning in old format,
+  parse and return the tuple of selectee, dependson, and the list of
+  selectors.
+  
+  WARNING: In the old format, there is no way of distinguishing
+  the selector from the complete expression that made select possible.
+  For example, it also includes selector's dependencies, or other selectors
+  for the same selectee. Therefore, the method returns all the terms in
+  the selector's expression as the list of selectors. Be careful that it
+  might include the options that do not actually select the selectee.
+  However, as long as an option that selects the selectee is in the list
+  of selectors, it means the selector is enabled and caused the unmet
+  dependency.
+  """
+  r = r"^warning: (.*?) selects (.*?) which has unmet direct dependencies (.*?)$"
+  s = re.search(r, warning_str)
+  selector_expr = s.group(1).strip()
+  selectors = get_all_terms_of_bool_expr(selector_expr)
+  selectee = s.group(2).strip()
+  dependson = s.group(3).strip()
+  return selectee, dependson, selectors
+
+def parse_warnings_oldformat(make_output: str) -> dict:
+  """Format: before the Linux kernel commit f8f69dc0b4e0
+  
+  Given make's output, parse and return all unmet dependency warnings
+  in old format.  Output dict maps selectees to list of selectors.
+  
+  Format is to have a complete warning in a single line:
+  ^warning: .* selects .* which has unmet direct dependencies .*$
+
+  Example:
+  "(A1 && B1 && C1) selects D1 which has unmet direct dependencies (E1 && F1)"
+
+  """
+  ret = {}
+
+  def check_line(l):
+    """Given a single line, check if unmet warning exists"""
+    r = r"^warning: .* selects .* which has unmet direct dependencies .*$"
+    ret = re.findall(r, l)
+    return len(ret) > 0
+  
+  # Iterate over each line and check.
+  for l in make_output.split('\n'):
+    l = l.strip()
+    if check_line(l.strip()):
+      # There is a udd warning: add it to the results
+      selectee, _, selectors = process_warning_oldformat(l)
+      ret[selectee] = ret.get(selectee, [])
+      for s in selectors:
+        ret[selectee].append(s)
+
+  return ret
+
+###########################################################################
+# TESTS ###################################################################
+###########################################################################
+
+def test_parse_warnings_oldformat():
+  print("running test_parse_warnings_oldformat()")
+  multiple_warnings_str = \
+    """warning: (A1 && B1 && C1) selects D1 which has unmet direct dependencies (E1 && F1)\n
+       warning: (A2) selects B2 which has unmet direct dependencies (C2 && D2)\n
+       warning: (A3 && B3) selects C3 which has unmet direct dependencies (D3)\n
+       warning: (M4) selects N4 which has unmet direct dependencies (A4)\n
+       warning: (M4) selects A5 which has unmet direct dependencies (B5)\n
+       warning: (M5) selects N4 which has unmet direct dependencies (A6)"""
+
+  ret = parse_warnings_oldformat(multiple_warnings_str)
+  # SELECTOR -> SELECTEE
+  # A1 -> D1
+  # A2 -> B2
+  # A3 -> C3
+  # M4 -> N4
+  # M4 -> A5
+  # M5 -> N4
+
+  # Check unique selectors
+  unique_selectees = ["D1", "B2", "C3", "N4", "A5"]
+  assert sorted(list(ret.keys())) == sorted(unique_selectees)
+
+  # Check selectors lists
+  assert sorted(ret["D1"]) == sorted(["A1", "B1", "C1"])
+  assert sorted(ret["B2"]) == sorted(["A2"])
+  assert sorted(ret["C3"]) == sorted(["A3", "B3"])
+  assert sorted(ret["N4"]) == sorted(["M4", "M5"])
+  assert sorted(ret["A5"]) == sorted(["M4"])
+
+def test_process_warning_oldformat():
+  print("running test_process_warning_oldformat()")
+  s1 = "warning: (DRM_RADEON && DRM_AMDGPU && DRM_NOUVEAU && DRM_I915 && DRM_GMA500 && DRM_SHMOBILE && DRM_TILCDC && DRM_FSL_DCU && DRM_TINYDRM && DRM_PARADE_PS8622 && FB_BACKLIGHT && FB_ARMCLCD && FB_MX3 && USB_APPLEDISPLAY && FB_OLPC_DCON && ACPI_CMPC && SAMSUNG_Q10) selects BACKLIGHT_CLASS_DEVICE which has unmet direct dependencies (HAS_IOMEM && BACKLIGHT_LCD_SUPPORT)"
+  selectee1, dependson1, selector1 = process_warning_oldformat(s1)
+  assert selectee1 == "BACKLIGHT_CLASS_DEVICE"
+  assert dependson1 == "(HAS_IOMEM && BACKLIGHT_LCD_SUPPORT)"
+  assert selector1 == ["DRM_RADEON", "DRM_AMDGPU", "DRM_NOUVEAU", "DRM_I915", "DRM_GMA500", "DRM_SHMOBILE", "DRM_TILCDC", "DRM_FSL_DCU", "DRM_TINYDRM", "DRM_PARADE_PS8622", "FB_BACKLIGHT", "FB_ARMCLCD", "FB_MX3", "USB_APPLEDISPLAY", "FB_OLPC_DCON", "ACPI_CMPC", "SAMSUNG_Q10"]
+
+  s2 = "warning: (STM32_DFSDM_ADC) selects IIO_BUFFER_HW_CONSUMER which has unmet direct dependencies (IIO && IIO_BUFFER)"
+  selectee2, dependson2, selector2 = process_warning_oldformat(s2)
+  assert selectee2 == "IIO_BUFFER_HW_CONSUMER"
+  assert dependson2 == "(IIO && IIO_BUFFER)"
+  assert selector2 == ["STM32_DFSDM_ADC"]
+
+def test_get_all_terms_of_bool_expr():
+  print("running test_get_all_terms_of_bool_expr()")
+  assert ["HAS_IOMEM", "BACKLIGHT_LCD_SUPPORT"] == get_all_terms_of_bool_expr("(HAS_IOMEM && BACKLIGHT_LCD_SUPPORT)")
+  assert ["HAS_IOMEM"] == get_all_terms_of_bool_expr("(HAS_IOMEM)")

--- a/kmax/udd_warning_parser.py
+++ b/kmax/udd_warning_parser.py
@@ -1,40 +1,9 @@
 # unmet direct dependency warnings parser
-import re
-
-def parse_warnings(make_output: str) -> dict:
-    """Parse and return the unmet direct dependency warnings from make
-    output (make olddefconfig).
-
-    Returns a dict that maps selectees to list of selectors.
-
-    The unmet direct dependency warning message format was changed with
-    the Linux kernel commit f8f69dc0b4e0. This method can parse for both
-    formats. However, the method asserts that a single format is used in
-    a given make output.
-    """
-    new_format_ret = parse_warnings_newformat(make_output)
-    old_format_ret = parse_warnings_oldformat(make_output)
-
-    # Can't have warnings in both formats in a make output.
-    assert not (len(new_format_ret) > 0 and len(old_format_ret) > 0)
-
-    if new_format_ret:
-        return new_format_ret
-    elif old_format_ret:
-        return old_format_ret
-    else:
-        return {} #< no unmet dependency warnings.
-
-
-###########################################################################
-# NEW FORMAT PARSER (after the linux kernel commit f8f69dc0b4e0) ##########
-###########################################################################
+import os, re, pprint, textwrap, argparse
 
 # given the content of the make output possibly including multiple warnings
 # parses the content and returns {selected: {selecters} }
-def parse_warnings_newformat(make_output):
-    """Format: after the Linux kernel commit f8f69dc0b4e0
-    """
+def parse_warnings(make_output):
     selected_prefix = r"WARNING: unmet direct dependencies detected for "
     selected_suffix = r"\n"
     selected_re = selected_prefix + "(.*?)" + selected_suffix
@@ -45,14 +14,12 @@ def parse_warnings_newformat(make_output):
     for i in range(len(warning_start_indices) - 1):
         warning_str_ranges.append( (warning_start_indices[i], warning_start_indices[i+1]) )
 
-    res = [ process_warning_newformat(make_output[s:e]) for s,e in warning_str_ranges ]
+    res = [ process_warning(make_output[s:e]) for s,e in warning_str_ranges ]
 
     return dict( (selected, selecters) for selected, _, selecters in res )
 
 # processes the first warning encountered. used as helper to parse_warnings()
-def process_warning_newformat(warning_str):
-    """Format: after the Linux kernel commit f8f69dc0b4e0
-    """
+def process_warning(warning_str):
     # get the selected
     selected_prefix = r"WARNING: unmet direct dependencies detected for "
     selected_suffix = r"\n"
@@ -73,139 +40,3 @@ def process_warning_newformat(warning_str):
     selecters = set([m.group(1).strip() for m in re.finditer(selecter_re, warning_str)])
 
     return selected, dependson, selecters
-
-###########################################################################
-# OLD FORMAT PARSER (before the linux kernel commit f8f69dc0b4e0) ########
-###########################################################################
-
-def get_all_terms_of_bool_expr(expr):
-  """Given a string boolean expression, return all the terms in the order
-  they appear. in the expression.
-
-  Expected format: starts with "(" and ends with ")"
-
-  Example input/output:
-  "(A && B)" returns ["A", "B"]
-  "(A)" returns "A"
-  """
-  # starts with "(", ends with ")", non-empty content
-  assert expr
-  assert len(expr) > 2
-  assert expr[0] == "("
-  assert expr[-1] == ")"
-
-  r = "[\( ]([a-zA-Z0-9_]*)[ \)]"
-  match_results = re.findall(r, expr)
-  assert match_results
-  return match_results
-
-def process_warning_oldformat(warning_str):
-  """Format: before the Linux kernel commit f8f69dc0b4e0
-  
-  Given a single line of unmet direct dependency warning in old format,
-  parse and return the tuple of selectee, dependson, and the list of
-  selectors.
-  
-  WARNING: In the old format, there is no way of distinguishing
-  the selector from the complete expression that made select possible.
-  For example, it also includes selector's dependencies, or other selectors
-  for the same selectee. Therefore, the method returns all the terms in
-  the selector's expression as the list of selectors. Be careful that it
-  might include the options that do not actually select the selectee.
-  However, as long as an option that selects the selectee is in the list
-  of selectors, it means the selector is enabled and caused the unmet
-  dependency.
-  """
-  r = r"^warning: (.*?) selects (.*?) which has unmet direct dependencies (.*?)$"
-  s = re.search(r, warning_str)
-  selector_expr = s.group(1).strip()
-  selectors = get_all_terms_of_bool_expr(selector_expr)
-  selectee = s.group(2).strip()
-  dependson = s.group(3).strip()
-  return selectee, dependson, selectors
-
-def parse_warnings_oldformat(make_output: str) -> dict:
-  """Format: before the Linux kernel commit f8f69dc0b4e0
-  
-  Given make's output, parse and return all unmet dependency warnings
-  in old format.  Output dict maps selectees to list of selectors.
-  
-  Format is to have a complete warning in a single line:
-  ^warning: .* selects .* which has unmet direct dependencies .*$
-
-  Example:
-  "(A1 && B1 && C1) selects D1 which has unmet direct dependencies (E1 && F1)"
-
-  """
-  ret = {}
-
-  def check_line(l):
-    """Given a single line, check if unmet warning exists"""
-    r = r"^warning: .* selects .* which has unmet direct dependencies .*$"
-    ret = re.findall(r, l)
-    return len(ret) > 0
-  
-  # Iterate over each line and check.
-  for l in make_output.split('\n'):
-    l = l.strip()
-    if check_line(l.strip()):
-      # There is a udd warning: add it to the results
-      selectee, _, selectors = process_warning_oldformat(l)
-      ret[selectee] = ret.get(selectee, [])
-      for s in selectors:
-        ret[selectee].append(s)
-
-  return ret
-
-###########################################################################
-# TESTS ###################################################################
-###########################################################################
-
-def test_parse_warnings_oldformat():
-  print("running test_parse_warnings_oldformat()")
-  multiple_warnings_str = \
-    """warning: (A1 && B1 && C1) selects D1 which has unmet direct dependencies (E1 && F1)\n
-       warning: (A2) selects B2 which has unmet direct dependencies (C2 && D2)\n
-       warning: (A3 && B3) selects C3 which has unmet direct dependencies (D3)\n
-       warning: (M4) selects N4 which has unmet direct dependencies (A4)\n
-       warning: (M4) selects A5 which has unmet direct dependencies (B5)\n
-       warning: (M5) selects N4 which has unmet direct dependencies (A6)"""
-
-  ret = parse_warnings_oldformat(multiple_warnings_str)
-  # SELECTOR -> SELECTEE
-  # A1 -> D1
-  # A2 -> B2
-  # A3 -> C3
-  # M4 -> N4
-  # M4 -> A5
-  # M5 -> N4
-
-  # Check unique selectors
-  unique_selectees = ["D1", "B2", "C3", "N4", "A5"]
-  assert sorted(list(ret.keys())) == sorted(unique_selectees)
-
-  # Check selectors lists
-  assert sorted(ret["D1"]) == sorted(["A1", "B1", "C1"])
-  assert sorted(ret["B2"]) == sorted(["A2"])
-  assert sorted(ret["C3"]) == sorted(["A3", "B3"])
-  assert sorted(ret["N4"]) == sorted(["M4", "M5"])
-  assert sorted(ret["A5"]) == sorted(["M4"])
-
-def test_process_warning_oldformat():
-  print("running test_process_warning_oldformat()")
-  s1 = "warning: (DRM_RADEON && DRM_AMDGPU && DRM_NOUVEAU && DRM_I915 && DRM_GMA500 && DRM_SHMOBILE && DRM_TILCDC && DRM_FSL_DCU && DRM_TINYDRM && DRM_PARADE_PS8622 && FB_BACKLIGHT && FB_ARMCLCD && FB_MX3 && USB_APPLEDISPLAY && FB_OLPC_DCON && ACPI_CMPC && SAMSUNG_Q10) selects BACKLIGHT_CLASS_DEVICE which has unmet direct dependencies (HAS_IOMEM && BACKLIGHT_LCD_SUPPORT)"
-  selectee1, dependson1, selector1 = process_warning_oldformat(s1)
-  assert selectee1 == "BACKLIGHT_CLASS_DEVICE"
-  assert dependson1 == "(HAS_IOMEM && BACKLIGHT_LCD_SUPPORT)"
-  assert selector1 == ["DRM_RADEON", "DRM_AMDGPU", "DRM_NOUVEAU", "DRM_I915", "DRM_GMA500", "DRM_SHMOBILE", "DRM_TILCDC", "DRM_FSL_DCU", "DRM_TINYDRM", "DRM_PARADE_PS8622", "FB_BACKLIGHT", "FB_ARMCLCD", "FB_MX3", "USB_APPLEDISPLAY", "FB_OLPC_DCON", "ACPI_CMPC", "SAMSUNG_Q10"]
-
-  s2 = "warning: (STM32_DFSDM_ADC) selects IIO_BUFFER_HW_CONSUMER which has unmet direct dependencies (IIO && IIO_BUFFER)"
-  selectee2, dependson2, selector2 = process_warning_oldformat(s2)
-  assert selectee2 == "IIO_BUFFER_HW_CONSUMER"
-  assert dependson2 == "(IIO && IIO_BUFFER)"
-  assert selector2 == ["STM32_DFSDM_ADC"]
-
-def test_get_all_terms_of_bool_expr():
-  print("running test_get_all_terms_of_bool_expr()")
-  assert ["HAS_IOMEM", "BACKLIGHT_LCD_SUPPORT"] == get_all_terms_of_bool_expr("(HAS_IOMEM && BACKLIGHT_LCD_SUPPORT)")
-  assert ["HAS_IOMEM"] == get_all_terms_of_bool_expr("(HAS_IOMEM)")

--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,5 @@ setup(
         'whatthepatch',
         'packaging',
     ],
+    include_package_data=True,
 )


### PR DESCRIPTION
This does the following changes to have kismet run for older linux kernel versions:
* backport kextract fixes from newer versions to older kextract versions (3.19 and 4.12.8)
* let kismet validate with older kbuild versions by parsing dependency warning messages in old format

Fixes https://github.com/paulgazz/kmax/issues/163
Fixes #167 