### PR TITLE
kismet: raise specific error when Kconfig files can't be opened

### DIFF
--- a/kmax/arch.py
+++ b/kmax/arch.py
@@ -1,13 +1,13 @@
 
 import os
-import sys
+import re
 import subprocess
 import random
 import string
 import pickle
 import z3
 import logging
-from kmax.vcommon import getLogger
+from kmax.vcommon import getLogger, run
 import kmax.kextractcommon
 
 # TODO(necip): test: test compatibility with the existing file formats
@@ -764,22 +764,50 @@ class Arch:
 
     assert kextract_module_versions
 
+    missing_kconfig_files = []
+    def get_missing_kconfig_file_messages(make_stderr: str) -> list:
+      """Example: drivers/media/platform/Kconfig:69: can't open file "drivers/media/platform/am437x/Kconfig"
+
+      For instance, the Linux kernel version at the commit 012e3ca3cb4d7f
+      has this issue.
+      """
+      ret = []
+      for l in make_stderr.split('\n'): 
+        l = l.strip()
+        found = re.findall(r"^.*: can't open file \".*$", l)
+        if found:
+          ret.extend(found)
+      return ret
+
     while kextract_module_versions:
       kextract_version=kextract_module_versions.pop() # pop the next version to try
       command = [ "kextractlinux", self.name, kextract_file, "--module-version", kextract_version]
       self.__logger.debug("Running kextract tool to generate kextract (module version: %s)." % kextract_version)
-      _, _, ret_code = self.__run_command(command, cwd=self.__linux_ksrc)
+      _, ke_stderr_bytes, ret_code = self.__run_command(command, cwd=self.__linux_ksrc)
       if ret_code == 0:
         break
       else:
         self.__logger.debug("Kextract failed (module version: %s, return code: %d)." % (kextract_version, ret_code))
-        if kextract_module_versions: self.__logger.debug("Trying next latest kextract module version: %s" % kextract_module_versions[-1])
+        # Check for missing Kconfig files.  Only report missing Kconfig
+        # files after all kextract versions are tried to give all versions
+        # a chance.
+        ke_stderr_str = str(ke_stderr_bytes.decode('utf-8'))
+        missing_files = get_missing_kconfig_file_messages(ke_stderr_str)
+        if missing_files:
+          self.__logger.debug("Detected missing Kconfig files: %s" % missing_files)
+          missing_kconfig_files = missing_files
+        if kextract_module_versions:
+          self.__logger.debug("Trying next latest kextract module version: %s" % kextract_module_versions[-1])
         os.remove(kextract_file)
+    
 
     if ret_code != 0:
       assert not kextract_module_versions
-      self.__logger.error("Error running kextract: kextract file couldn't be generated.")
-      raise Arch.KextractFormulaGenerationError()
+      if missing_kconfig_files: #< Known reason: Kconfig files were missing
+        raise Arch.CantOpenKconfigFiles(missing_kconfig_files)
+      else: #< Unknown reason, raise a generic assertion.
+        self.__logger.error("Error running kextract: kextract file couldn't be generated.")
+        raise Arch.KextractFormulaGenerationError()
     else:
       self.__logger.debug("kextract was successfully generated.")
 
@@ -1257,6 +1285,12 @@ class Arch:
   class KextractFormulaGenerationError(FormulaGenerationError):
     def __init__(self):
       super().__init__(formula_type="kextract")
+
+  class CantOpenKconfigFiles(KextractFormulaGenerationError):
+    def __init__(self, kextract_complaints):
+      super().__init__()
+      self.kextract_complaints = kextract_complaints
+      self.message = "kextract formulas couldn't be generated: can't open Kconfig files: %s" % kextract_complaints
 
   ### Can't generate formula: kclause
   class KclauseFormulaGenerationError(FormulaGenerationError):

--- a/kmax/kismet
+++ b/kmax/kismet
@@ -233,7 +233,7 @@ def get_unmet_constraints(arch, selectors=None, selectees=None, syntactical_opti
   
   return unmet_constraints_mapping
 
-if __name__ == '__main__':
+def main():
   t_start_main = __get_time_refpoint()
 
   argparser = argparse.ArgumentParser()
@@ -1033,3 +1033,15 @@ if __name__ == '__main__':
               row = get_row(entry = sat_option, constraint_type=i+1)
               if row: csv_writer.writerow(row)
     info("Summary csv was written.")
+
+if __name__ == '__main__':
+  try:
+    main()
+  except Arch.CantOpenKconfigFiles as e:
+    kc = e.kextract_complaints
+    message = "Can't open Kconfig files:"
+    for i in kc:
+      message += "\n  %s" % i
+    error(message)
+    exit(1)
+


### PR DESCRIPTION
Catch exceptions of type `Arch.CantOpenKconfigFiles` and write a specific
error message to inform the issue with the input Kconfig specifications.

For example, when you run the following in a Linux git copy:
```
git checkout 012e3ca3cb4d7f
kismet -a x86_64
```

kismet will output (tail of the kismet logs) and terminate:

```
ERROR: Can't open Kconfig files:
  drivers/media/platform/Kconfig:69: can't open file "drivers/media/platform/am437x/Kconfig"
```

Fixes https://github.com/paulgazz/kmax/issues/164