### PR TITLE
kismet: print INFO logs on stdout

### DIFF
--- a/kmax/kismet
+++ b/kmax/kismet
@@ -54,7 +54,7 @@ class UnmetDepResult(enum.Enum):
   UNMET_SAFE_PRECISE_PASS = 3
 
 def info(msg, ending="\n"):
-  sys.stderr.write("INFO: %s%s" % (msg, ending))
+  sys.stdout.write("INFO: %s%s" % (msg, ending))
 
 def warning(msg, ending="\n"):
   sys.stderr.write("WARNING: %s%s" % (msg, ending))


### PR DESCRIPTION
kismet used to print info/warning/error on stderr. To distinguish, print
info on stdout and keep warning/error on stderr.