### PR TITLE
koverage: add timeout durations options, use explicit values in results when timeouts happen

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -298,6 +298,8 @@ The results may one of three values for each line for both headers and source fi
     * If header, file is not included in any of the compilation units
       preprocessed.  However, (file,line) might be included by some
       unseen compilation unit.
+* `TIMEOUT_MAKE_OLDDEFCONFIG`: Running `make olddefconfig` on the input configuration file timed out.
+* `TIMEOUT_MAKE`: Running `make` on the build target timed out.
 
 
 ## Annotated Example

--- a/kmax/koverage
+++ b/kmax/koverage
@@ -38,6 +38,7 @@ KOVERAGE_EXITCODE_MAKE_OLDDEFCONFIG_TIMEDOUT=11
 KOVERAGE_EXITCODE_CHECK_PATCH_FILE_NOT_FOUND=12
 KOVERAGE_EXITCODE_CHECK_COVREQ_FILE_NOT_FOUND=13
 KOVERAGE_EXITCODE_SCRATCHDIR_EXISTS=14
+KOVERAGE_EXITCODE_INVALID_TIMEOUT_ARG=15
 
 import json
 import sys
@@ -155,7 +156,9 @@ class LineCoverage(str, Enum):
 def check_config(
     cross_compiler: str, arch: str, linux_dir: str, 
     coverage_requirements: dict, build_targets: dict, config_file: str,
-    scratch_dir: str) -> dict:
+    scratch_dir: str, timeout_olddefconfig : int, timeout_make_dir : int,
+    timeout_make_unit : int
+    ) -> dict:
     """
     coverage_requirements is a dictionary describing the files to check
     coverage in the build by the given Linux configuration file at config_file.
@@ -180,11 +183,6 @@ def check_config(
         }
     }
     """
-    # TODO: make followings variable
-    olddefconfig_timeout = 300 
-    directory_timeout = 10800
-    file_timeout = 900
-
     # Copy the configuration file to scratch_dir as doing olddefconfig
     # will modify the configuration file.
     new_config_file_path = os.path.join(scratch_dir, "evaluated.config")
@@ -210,10 +208,10 @@ def check_config(
     logger.debug("Running olddefconfig: \"%s\"\n" % olddef_cmd)
 
     try:
-        _, _, retcode, time_elapsed = run(olddef_cmd, timeout=olddefconfig_timeout, shell=True, cwd=linux_dir)
+        _, _, retcode, time_elapsed = run(olddef_cmd, timeout=timeout_olddefconfig, shell=True, cwd=linux_dir)
         logger.debug("Running olddefconfig completed in %.2f seconds, retcode: %s\n" % (time_elapsed, retcode))
     except TimeoutExpired:
-        logger.error("Running olddefconfig on the input Linux configuration file timed out (timeout=%.2fsec).\n" % olddefconfig_timeout)
+        logger.error("Running olddefconfig on the input Linux configuration file timed out (timeout=%.2fsec).\n" % timeout_olddefconfig)
         exit(KOVERAGE_EXITCODE_MAKE_OLDDEFCONFIG_TIMEDOUT)
 
     # Copy the preprocessed config file.
@@ -257,9 +255,9 @@ def check_config(
         # user can possibly define larger timeout values.
         is_build_target_file = build_target.endswith(".i") or build_target.endswith(".o")
         if is_build_target_file:
-            make_timeout = file_timeout
+            make_timeout = timeout_make_unit
         else:
-            make_timeout = directory_timeout
+            make_timeout = timeout_make_dir
 
         # Run make to get the preprocessed file.
         make_cmd = "%s %s" % (core_make_command, build_target)
@@ -801,6 +799,21 @@ def main():
         help="""Path to the executable make script for cross compilation."""
              """  Defaults to \"make.cross\".""",
         default="make.cross")
+    argparser.add_argument("--timeout-olddefconfig",
+        type=int,
+        help="""Timeout duration for "make olddefconfig" in seconds."""
+             """  0 means no limits.  Defaults to 300 (5 minutes).""",
+        default=300)
+    argparser.add_argument("--timeout-make-dir",
+        type=int,
+        help="""Timeout duration for make'ing directory targets (e.g., kernel/), in seconds."""
+             """  0 means no limits.  Defaults to 10800 (3 hours).""",
+        default=10800)
+    argparser.add_argument("--timeout-make-unit",
+        type=int,
+        help="""Timeout duration for make'ing unit targets (e.g., kernel/fork.o), in seconds."""
+             """  0 means no limits.  Defaults to 900 (15 minutes).""",
+        default=900)
     argparser.add_argument("--config",
         type=str,
         required=True,
@@ -872,6 +885,9 @@ def main():
 
     args = argparser.parse_args()
     cross_compiler = args.cross_compiler
+    timeout_olddefconfig = args.timeout_olddefconfig
+    timeout_make_dir = args.timeout_make_dir
+    timeout_make_unit = args.timeout_make_unit
     config_file = args.config
     arch = args.arch
     check_arg = args.check
@@ -894,6 +910,17 @@ def main():
     assert os.path.isdir(linux_ksrc)
     assert os.path.isfile(config_file)
     assert arch in Arch.ARCHS
+    def check_timeout(timeout_duration : int, option: str):
+        if timeout_duration < 0:
+            logger.error("Timeout duration (%s) must be >= 0 (%s was given).\n" % (option, timeout_duration))
+            exit(KOVERAGE_EXITCODE_INVALID_TIMEOUT_ARG)
+        elif timeout_duration == 0:
+            return None
+        else:
+            return timeout_duration
+    timeout_olddefconfig = check_timeout(timeout_olddefconfig, "--timeout-olddefconfig")
+    timeout_make_dir = check_timeout(timeout_make_dir, "--timeout-make-dir")
+    timeout_make_unit = check_timeout(timeout_make_unit, "--timeout-make-unit")
 
     # Create the scratch directory.
     if os.path.exists(scratch_dir):
@@ -964,7 +991,9 @@ def main():
 
     # Determine if the config builds the target (file:line)s.
     logger.info("Starting coverage checks.\n")
-    coverage_results_vcovreq_lines = check_config(cross_compiler, arch, linux_ksrc, validation_covreq, build_targets, config_file, scratch_dir)
+    coverage_results_vcovreq_lines = check_config(cross_compiler, arch,
+        linux_ksrc, validation_covreq, build_targets, config_file, scratch_dir,
+        timeout_olddefconfig, timeout_make_dir, timeout_make_unit)
     logger.info("Finished coverage checks.\n")
     logger.debug("Coverage results in terms of validation coverage requirements: \"%s\"\n" % coverage_results_vcovreq_lines)
     # Map line numbers in coverage results back to the lines in the

--- a/kmax/koverage
+++ b/kmax/koverage
@@ -21,6 +21,9 @@ definition for LineCoverage):
     * If header, file is not included in any of the compilation units
       preprocessed.  However, (file,line) might be included by some
       unseen compilation unit.
+* TIMEOUT_MAKE_OLDDEFCONFIG: Running make olddefconfig on the input
+    configuration file timed out.
+* TIMEOUT_MAKE: Running make on the build target timed out.
 """
 
 KOVERAGE_EXITCODE_CHECK_ARG_NEEDED=1
@@ -34,7 +37,7 @@ KOVERAGE_EXITCODE_COVREQ_NO_LINE_FOUND=7
 KOVERAGE_EXITCODE_COVREQ_INVALID_LINE_LESS_THAN_1=8
 KOVERAGE_EXITCODE_COVREQ_INVALID_LINE_MORE_THAN_LINECOUNT=9
 KOVERAGE_EXITCODE_MALFORMED_CHECK_FILELINE_FORMAT=10
-KOVERAGE_EXITCODE_MAKE_OLDDEFCONFIG_TIMEDOUT=11
+# KOVERAGE_EXITCODE_MAKE_OLDDEFCONFIG_TIMEDOUT=11 #< No longer used.
 KOVERAGE_EXITCODE_CHECK_PATCH_FILE_NOT_FOUND=12
 KOVERAGE_EXITCODE_CHECK_COVREQ_FILE_NOT_FOUND=13
 KOVERAGE_EXITCODE_SCRATCHDIR_EXISTS=14
@@ -137,17 +140,26 @@ class LineCoverage(str, Enum):
        * If header, file is not included in any of the source files
          preprocessed.  However, file:line might be included by some
          unseen source file.
+
+    * TIMEOUT_MAKE_OLDDEFCONFIG: Running make olddefconfig on the input
+     configuration file timed out.
+
+    * TIMEOUT_MAKE: Running make on the build target timed out.
     """
     INCLUDED = 'INCLUDED'
     LINE_EXCLUDED_FILE_INCLUDED = 'LINE_EXCLUDED_FILE_INCLUDED'
     FILE_EXCLUDED = 'FILE_EXCLUDED'
+    TIMEOUT_MAKE_OLDDEFCONFIG = 'TIMEOUT_MAKE_OLDDEFCONFIG'
+    TIMEOUT_MAKE = 'TIMEOUT_MAKE'
 
     def parse(enum_str: str):
         """Parse a LineCoverage string into LineCoverage instance."""
         m = {
             'INCLUDED' : LineCoverage.INCLUDED,
             'LINE_EXCLUDED_FILE_INCLUDED' : LineCoverage.LINE_EXCLUDED_FILE_INCLUDED,
-            'FILE_EXCLUDED' : LineCoverage.FILE_EXCLUDED
+            'FILE_EXCLUDED' : LineCoverage.FILE_EXCLUDED,
+            'TIMEOUT_MAKE_OLDDEFCONFIG' : LineCoverage.TIMEOUT_MAKE_OLDDEFCONFIG,
+            'TIMEOUT_MAKE' : LineCoverage.TIMEOUT_MAKE
         }
         assert enum_str in m
         return m[enum_str]
@@ -211,8 +223,27 @@ def check_config(
         _, _, retcode, time_elapsed = run(olddef_cmd, timeout=timeout_olddefconfig, shell=True, cwd=linux_dir)
         logger.debug("Running olddefconfig completed in %.2f seconds, retcode: %s\n" % (time_elapsed, retcode))
     except TimeoutExpired:
-        logger.error("Running olddefconfig on the input Linux configuration file timed out (timeout=%.2fsec).\n" % timeout_olddefconfig)
-        exit(KOVERAGE_EXITCODE_MAKE_OLDDEFCONFIG_TIMEDOUT)
+        logger.warning("Running make olddefconfig on the input configuration file timed out (timeout=%.2fsec).\n" % timeout_olddefconfig)
+        # Write info in scratch dir.
+        scratch_dir_olddef_timeout_file = os.path.join(scratch_dir, "make_olddefconfig.timeout")
+        with open(scratch_dir_olddef_timeout_file, 'w') as f:
+            f.write("make olddefconfig timed out after %.2f seconds" % timeout_olddefconfig)
+        # Fill all results with LineCoverage.TIMEOUT_MAKE_OLDDEFCONFIG and return.
+        def get_results_filled_with_value(filelines_to_check, value):
+            ret = {}
+            for file in filelines_to_check:
+                requested_lines = filelines_to_check[file]
+                ret[file] = []
+                for l in requested_lines:
+                    ret[file].append((l, value))
+            return ret
+        src_results = get_results_filled_with_value(coverage_requirements.get("sourcefile_loc", {}), LineCoverage.TIMEOUT_MAKE_OLDDEFCONFIG)
+        header_results = get_results_filled_with_value(coverage_requirements.get("headerfile_loc", {}), LineCoverage.TIMEOUT_MAKE_OLDDEFCONFIG)
+        assert src_results
+        result = {"sourcefile_loc" : src_results}
+        if header_results:
+            result.update({"headerfile_loc" : header_results})
+        return result
 
     # Copy the preprocessed config file.
     after_olddefconfig_config_file_path = os.path.join(scratch_dir, "after_olddefconfig.config")
@@ -262,6 +293,7 @@ def check_config(
         # Run make to get the preprocessed file.
         make_cmd = "%s %s" % (core_make_command, build_target)
         logger.debug("Running make to preprocess file \"%s\", command: \"%s\"\n" % (source_file, make_cmd))
+        make_timedout = False
         try:
             make_stdout, make_stderr, make_retcode, make_time_elapsed = run(make_cmd, timeout=make_timeout, shell=True, cwd = linux_dir)
             logger.debug("Finished running make, retcode=%s time_elapsed=%.2fsec\n" % (make_retcode, make_time_elapsed))
@@ -287,9 +319,13 @@ def check_config(
             w("make.retcode", "%s" % make_retcode)
 
         except TimeoutExpired:
-            logger.debug("Running make timedout for \"%s\", (timeout=%.2fsec).\n" % (source_file, make_timeout))
-            make_stdout = make_stderr = retcode = time_elapsed = "build timed out"
+            make_timedout = True
             preprocessed_file_created[source_file] = False
+            logger.debug("Running make timed out for \"%s\", (timeout=%.2fsec).\n" % (source_file, make_timeout))
+            # Save timeout information.
+            make_timeout_fpath = os.path.join(srcfile_scratch_dir, "make.timeout")
+            with open(make_timeout_fpath, 'w') as f:
+                f.write("build timed out after %.2f seconds" % make_timeout)
 
         # Without preprocessed file, we cannot determine whether lines are included.
         if preprocessed_file_created[source_file]:
@@ -333,7 +369,10 @@ def check_config(
         for file in filelines_to_check:
             requested_lines = filelines_to_check[file]
             ret[file] = []
-            if file in included_filelines: #< File is included.
+            if make_timedout:
+                for l in requested_lines:
+                    ret[file].append((l, LineCoverage.TIMEOUT_MAKE))
+            elif file in included_filelines: #< File is included.
                 included_lines = included_filelines[file]
                 # Get and record results per line.
                 for l in requested_lines:


### PR DESCRIPTION
**koverage: add command line options to control timeout durations (https://github.com/paulgazz/kmax/commit/ee78d1b7bacb2ae5e3502e3de4e4c2ae75e38417)**
Timeout durations for running make commands were fixed. Introduce new
command line options to control the timeout durations, which are:
--timeout-make-olddefconfig, --timeout-make-dir, --timeout-make-unit


**koverage: use explicit inclusion values for timeouts (https://github.com/paulgazz/kmax/commit/cb0dea436445b4f685bf545124081b8e52b9b640)**
When make timed out, koverage used "FILE_EXCLUDED" as the inclusion
value for the target lines.  However, timeouts do not mean the file/line
is excluded from compilation. Instead use new values, which are
TIMEOUT_MAKE_OLDDEFCONFIG and TIMEOUT_MAKE.