### PR TITLE
Prioritize architectures of compilation units in arch/ directories

### DIFF
--- a/kmax/arch.py
+++ b/kmax/arch.py
@@ -57,6 +57,9 @@ class Arch:
   # architecture-specific configs for known linux architectures
   ARCH_CONFIGS = set([ "CONFIG_ALPHA", "CONFIG_ARC", "CONFIG_ARM", "CONFIG_ARM64", "CONFIG_C6X", "CONFIG_CSKY", "CONFIG_H8300", "CONFIG_HEXAGON", "CONFIG_IA64", "CONFIG_M68K", "CONFIG_MICROBLAZE", "CONFIG_MIPS", "CONFIG_NDS32", "CONFIG_NIOS2", "CONFIG_OPENRISC", "CONFIG_PARISC", "CONFIG_PPC64", "CONFIG_PPC32", "CONFIG_PPC", "CONFIG_RISCV", "CONFIG_S390", "CONFIG_SUPERH64", "CONFIG_SUPERH32", "CONFIG_SUPERH", "CONFIG_SPARC64", "CONFIG_SPARC32", "CONFIG_SPARC", "CONFIG_UML", "CONFIG_UNICORE32", "CONFIG_X86_64", "CONFIG_X86_32", "CONFIG_X86", "CONFIG_XTENSA" ])
 
+  def __repr__(self):
+    return "Arch(%s)" % self.name
+
   @staticmethod
   def get_archs_from_subdir(kbuild_path: str) -> list:
     """Get the architectures associated with the given arch/ subdirectory."""

--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -9,6 +9,7 @@ import json
 from collections import OrderedDict
 from kmax import patch
 import pathlib
+from functools import reduce
 
 z3_true = z3.BoolVal(True)
 
@@ -937,14 +938,34 @@ def klocalizerCLI():
   # Filter archs based on unit name
   #
   if not kclause_file :
+    # when the mandatory include list has an arch/ directory file, we
+    # know we must use that arch
     for unit, _ in include_list:
+      print(unit)
       if unit.startswith("arch/"):
         unit_archs = Arch.get_archs_from_subdir(unit)
         archs = [ arch for arch in archs if arch.name in unit_archs ]
         if not archs:
           logger.error("Resolved compilation unit is architecture-specific, but its architecture is not available: %s\n" % (unit))
           exit(9)
-  
+
+    # when the include-mutex flag includes an arch/ directory, we
+    # can't rule out other archs, since some lines may be in different
+    # architectures (unless all lines are arch/-specific).  we can,
+    # however, try those architectures first.
+    arch_specific = [ unit for unit, _ in include_mutex_list if unit.startswith("arch/") ]
+    non_arch = [ unit for unit, _ in include_mutex_list if unit not in arch_specific ]
+    # fold sets of archs found from the unit's path into a single set
+    arch_specific_archs = reduce(lambda accset, unit: accset.union(set(Arch.get_archs_from_subdir(unit))), arch_specific, set())
+    # get the set of corresponding arch objects
+    arch_specific_arch_objects = [ arch for arch in archs if arch.name in arch_specific_archs ]
+    # put the other arch_objects at the end of the list
+    other_arch_objects = [ arch for arch in archs if arch not in arch_specific_archs ]
+    if len(arch_specific_arch_objects) > 0:
+      logger.info("Unit(s) looks arch-specific.  Moving those architectures %s to the beginning of the list.\n" % (arch_specific_arch_objects))
+      archs = arch_specific_arch_objects + other_arch_objects
+    # print(archs)
+
   assert len(archs) > 0
   
   #


### PR DESCRIPTION
klocalizer uses a fixed-order list of architectures to try to localize when the architecture is not provided by the user.  Optimize this ordering by looking for files given to include-mutex that are in the arch/ directories by putting those architectures first in the list.

Example:
```
git checkout 35d02493dba1ae6386fac07072908717affc3ff8
git show > patch.diffa
make defconfig
cp .config defconfig
klocalizer --repair defconfig --include-mutex patch.diff
koverage --config patch.diff --check-patch patch.diff -o coverage.json --arch s390
```