### PR TITLE
Add COMPILER_INSTALL_PATH for make.cross

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ This tool will automatically "fix" your .config file so that it builds the lines
 
     sudo apt-get install -y libz3-java libjson-java sat4j unzip flex bison bc libssl-dev libelf-dev xz-utils lftp
     wget -O - https://raw.githubusercontent.com/appleseedlab/superc/master/scripts/install.sh | bash
-    export CLASSPATH=${CLASSPATH}:/usr/share/java/org.sat4j.core.jar:/usr/share/java/json-lib.jar:${HOME}/.local/share/superc/z3-4.8.12-x64-glibc-2.31/bin/com.microsoft.z3.jar:${HOME}/.local/share/superc/JavaBDD/javabdd-1.0b2.jar:${HOME}/.local/share/superc/xtc.jar:${HOME}/.local/share/superc/superc.jar
+    export COMPILER_INSTALL_PATH=$HOME/0day
+    export CLASSPATH=/usr/share/java/org.sat4j.core.jar:/usr/share/java/json-lib.jar:${HOME}/.local/share/superc/z3-4.8.12-x64-glibc-2.31/bin/com.microsoft.z3.jar:${HOME}/.local/share/superc/JavaBDD/javabdd-1.0b2.jar:${HOME}/.local/share/superc/xtc.jar:${HOME}/.local/share/superc/superc.jar:${CLASSPATH}
     export PATH=${PATH}:${HOME}/.local/bin/
 
 Too see it in action, start with a clone of the linux repository and create a patch file:


### PR DESCRIPTION
This also puts the superc classpath before the original classpath to avoid shadowing of java dependencies.

Fixes #191 