### PR TITLE
Support nonbool preservation when collecting sourceline presence conditions and when repairing without mutual exclusion

### DIFF
--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -1465,7 +1465,16 @@ def klocalizerCLI():
   assert not include_mutex_list
   for arch in archs:
     logger.info("Trying \"%s\"\n" % (arch.name))
-
+    if arch.name in approximate_configs:
+      approximate_config = approximate_configs[arch.name]
+    elif "default" in approximate_configs:
+      approximate_config = approximate_configs["default"]
+    else:
+      assert(False)
+      approximate_config = None
+    if no_nonbool_preservation:
+      approximate_config = None
+    
     #
     # SAT check for units only (without line constraints)
     #
@@ -1589,11 +1598,11 @@ def klocalizerCLI():
       if not reportallarchs and sample_count > 0:
 
         # Prepare the configs by sampling models
-        configs = [Klocalizer.get_config_from_model(model, arch, set_tristate_m=modules_arg, allow_non_visibles=allow_non_visibles)]
+        configs = [Klocalizer.get_config_from_model(model, arch, set_tristate_m=modules_arg, allow_non_visibles=allow_non_visibles, approximate_config=approximate_config)]
         for _ in range(sample_count-1):
           is_sat, model = model_sampler.sample_model()
           assert is_sat
-          configs.append(Klocalizer.get_config_from_model(model, arch, set_tristate_m=modules_arg, allow_non_visibles=allow_non_visibles))
+          configs.append(Klocalizer.get_config_from_model(model, arch, set_tristate_m=modules_arg, allow_non_visibles=allow_non_visibles, approximate_config=approximate_config))
         
         # Prepare the config filenames
         if sample_count == 1:

--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -802,7 +802,7 @@ def klocalizerCLI():
       line_constraints[unit2srcfile(unit)] = {}
   # This function uses values from global scope (linux ksrc, formulas dir, etc.)
   # but parametrizes the operation into srcfile and architecture.
-  def get_presence_conditions(srcfile, arch):
+  def get_presence_conditions(srcfile, arch, approximate_config):
     """Ensures SuperC configs for srcfile and computes the line presence
     conditions.
     
@@ -824,7 +824,7 @@ def klocalizerCLI():
     #
     logger.info("Computing line presence conditions for \"%s\"\n" % srcfile)
     superc_formulas_dir = SuperC.get_superc_formulas_dir(formulas, arch.name)
-    config_exists = superc.ensure_superc_config(srcfile, superc_formulas_dir, linux_ksrc, arch, cross_compiler, build_targets, compile_jobs, build_timeout, logger)
+    config_exists = superc.ensure_superc_config(srcfile, superc_formulas_dir, linux_ksrc, arch, approximate_config, cross_compiler, build_targets, compile_jobs, build_timeout, logger)
     if not config_exists:
       logger.debug("Failed to find/create SuperC config file for \"%s\"\n" % srcfile)
       error_msg = "Failed to compute line presence conditions for \"%s\": SuperC config generation error\n" % srcfile
@@ -1117,7 +1117,16 @@ def klocalizerCLI():
       if units_to_compute_pc:
         logger.info("Computing the line presence conditions under %s for the following units: %s\n" % (arch.name, " ".join(units_to_compute_pc)))
       for unit in units_to_compute_pc:
-        get_presence_conditions(unit2srcfile(unit), arch)
+        if arch.name in approximate_configs:
+          approximate_config = approximate_configs[arch.name]
+        elif "default" in approximate_configs:
+          approximate_config = approximate_configs["default"]
+        else:
+          assert(False)
+          approximate_config = None
+        if no_nonbool_preservation:
+          approximate_config = None
+        get_presence_conditions(unit2srcfile(unit), arch, approximate_config)
 
       # Presence conditions are computed.
 
@@ -1513,7 +1522,7 @@ def klocalizerCLI():
       srcfiles_with_line_requirements = ["%s.c" % u[:-len('.o')] for u, lines in all_comp_units_list if lines]
       logger.info("Computing the line presence conditions under %s for the following units: %s\n" % (arch.name, " ".join(srcfiles_with_line_requirements)))
       for unit in srcfiles_with_line_requirements:
-        get_presence_conditions(unit2srcfile(unit), arch)
+        get_presence_conditions(unit2srcfile(unit), arch, approximate_config)
 
       logger.debug("Getting additional line constraints.\n")
 

--- a/kmax/klocalizer.py
+++ b/kmax/klocalizer.py
@@ -368,7 +368,7 @@ class Klocalizer:
     set_tristate_m -- If set, set tristate symbols to `m` if on.
     allow_non_visibles -- Allow non-visible Kconfig configuration options to
     be set in the resulting config file.
-    approximate_config -- the original config file to approximate.  if set, will use this to set nonbool values instead of the default values
+    approximate_config -- the original config file to approximate.  if set, will use this to set nonbool values instead of the default values.  otherwise, set to None (the default)
     logger -- Logger.
     
     """

--- a/kmax/superc.py
+++ b/kmax/superc.py
@@ -396,7 +396,7 @@ class SuperC:
 
   def ensure_superc_config(self,
     srcfile: str, output_superc_configs_dir_path: str, linux_ksrc: str,
-    arch: Arch, cross_compiler, build_targets, compile_jobs, build_timeout,
+arch: Arch, approximate_config, cross_compiler, build_targets, compile_jobs, build_timeout,
     logger):
     """
     Ensure that SuperC configs exist for the input sourcefile.
@@ -431,7 +431,7 @@ class SuperC:
       # Localize a building configuration file.
       #
       output_config_file = logpath("kloc_localized_config")
-      ret_status, ret_arch, ret_exception = Klocalizer.localize_config([unit], output_config_file, linux_ksrc, [arch], logger)
+      ret_status, ret_arch, ret_exception = Klocalizer.localize_config([unit], output_config_file, linux_ksrc, [arch], {arch.name: approximate_config}, logger)
       # Write diagnostic info
       write_content_to_file(logpath("kloc_config_loc_status"), str(ret_status) + '\n')
       # no need to write ret_arch: there is already a single architecture


### PR DESCRIPTION
Previously, the use of the nonbools from the repaired config were only used for the --include-mutex algoritm.  Without this flag, a different algorithm is used (which assumes no mutual exclusion in the constraints and can therefore more be unsat).

Now, the nonbool preservation has also been added to that algorithm.

An example:

```
git checkout 0a434e0a2c9f4395e4560aac22677ef25ab4afd9
git show > patch.diff
cp .config defconfig
```

After this fix, the following will build successfully:
```
klocalizer -a arc --repair defconfig --include lib/decompress_unxz.o
make.cross ARCH=arc olddefconfig; make.cross ARCH=arc clean lib/decompress_unxz.o
```

Prior behavior is preserved by using the existing
`--no-nonbool-preservation` flag, which yields a broken build due to invalid non-boolean option settings:
```
klocalizer --no-nonbool-preservation -a arc --repair defconfig --include lib/decompress_unxz.o
make.cross ARCH=arc olddefconfig; make.cross ARCH=arc clean lib/decompress_unxz.o
```