### PR TITLE
Fix the check for a broken build when getting SuperC conditions

### DIFF
--- a/kmax/superc.py
+++ b/kmax/superc.py
@@ -456,7 +456,7 @@ arch: Arch, approximate_config, cross_compiler, build_targets, compile_jobs, bui
       write_content_to_file(logpath("build_unit_make_out"), str(make_out) + '\n')
       write_content_to_file(logpath("build_unit_make_err"), str(make_err) + '\n')
       write_content_to_file(logpath("build_unit_time_elapsed"), str(time_elapsed) + '\n')
-      if not is_unit_compiled:
+      if False in is_unit_compiled:
         logger.debug("Unit could not be compiled.\n")
         return False
       else:


### PR DESCRIPTION
You can trigger this bug before the fix with the following use of krepair:

commit=1a90bfd220201fbe050dfc15deaac20ca5f15638; git checkout -f $commit; git show > patch.diff; make defconfig; cp .config defconfig; klocalizer -v -a arc --repair defconfig --include-mutex patch.dif

Fixes #202 