### PR TITLE
Remove assertions that require a config to repair

### DIFF
--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -1163,7 +1163,6 @@ def klocalizerCLI():
         elif "default" in approximate_configs:
           approximate_config = approximate_configs["default"]
         else:
-          assert(False)
           approximate_config = None
         if no_nonbool_preservation:
           approximate_config = None
@@ -1452,7 +1451,6 @@ def klocalizerCLI():
       elif "default" in approximate_configs:
         approximate_config = approximate_configs["default"]
       else:
-        assert(False)
         approximate_config = None
       if no_nonbool_preservation:
         approximate_config = None
@@ -1530,7 +1528,6 @@ def klocalizerCLI():
     elif "default" in approximate_configs:
       approximate_config = approximate_configs["default"]
     else:
-      assert(False)
       approximate_config = None
     if no_nonbool_preservation:
       approximate_config = None


### PR DESCRIPTION
Previously, when generating a configuration file given constraints on config options, files, and/or lines, an assertion would trigger because there is no configuration file given as input to repair. klocalizer should be able to generate a config file according to constraints without an input file as was prior behavior.  This removes the asserts allow configuration file generation to proceed.

Fixes #223 