### PR TITLE
Fix bug in .config file generation that uses invalid nonbool value

### DIFF
--- a/kmax/klocalizer.py
+++ b/kmax/klocalizer.py
@@ -447,7 +447,12 @@ class Klocalizer:
         val, expr = val_and_expr.split("|", 1)
         # TODO: this will use the last def if there are multiple ones.
         # use constraint solver to pick the right one.
-        nonbool_defs[var] = val[1:-1] # strip the quotes
+        if val.startswith('"') and val.endswith('"'):
+          nonbool_defs[var] = val[1:-1] # strip the quotes
+        else:
+          # default value is from another variable, so it won't have a quoted value
+          # TODO: support assigning default values from other config options
+          pass
     for entry in model: # the model has some problem, we can't get the entry
       str_entry = str(entry)
       matches = token_pattern.match(str_entry)


### PR DESCRIPTION
A new feature from v4.5 uses Kconfig default values for nonbools.  It assumed the values are quoted literals.  But nonbool defaults may also be other configuration options.  This fix checks that only quoted literals are used as nonbool values.

Fixes #239 