### PR TITLE
setup.py: explicitly set dd version to 0.5.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'enum34',
         'regex',
         'z3-solver',
-        'dd',
+        'dd==0.5.7', # dd requires networkx >= 2.4 starting from 0.6.0
         'networkx==2.2', # for dd to work on python2
         'requests',
         'whatthepatch',


### PR DESCRIPTION
An error of dependency issue between networkx and dd was thrown during installation:

$ python3 setup.py install
...
error: networkx 2.2 is installed but networkx>=2.4 is required by {'dd'}

dd released a new version 0.6.0 recently which removed the support for old versions of python, and the networkx requirement was also updated to 2.4 accordingly.

Please refer to the following commit of dd repository:

https://github.com/tulip-control/dd
08ce37263ec8 ("REL: require Python >= 3.8")

    - REL: require `networkx >= 2.4` in `tests_require`,
      because this is the earliest `networkx` version that
      explicitly lists Python 3.8 in its Trove classifiers.

Since networkx is set to 2.2 to work on python2, here we can also set dd to an earlier release 0.5.7 to solve the dependency issue.

Reported-by: kernel test robot <lkp@intel.com>