### PR TITLE
Update the mailing to search for kismet bugs in the docs

### DIFF
--- a/docs/bugs_found.md
+++ b/docs/bugs_found.md
@@ -21,7 +21,9 @@ The [Intel 0-day](https://01.org/lkp) kernel test robot after their team include
 
 Linux kernel mailing list latest kismet reports:
 
-- <https://lore.kernel.org/all/?q=kismet>
+<!-- - <https://lore.kernel.org/all/?q=kismet> -->
+
+- <https://lore.kernel.org/oe-kbuild-all/?q=kismet>
 
 Initial reports in the weeks after integration:
 


### PR DESCRIPTION
Currently, the link to kismet bugs looks at the whole lkml, which can include other things called kismet or other messages.

Switch to oe-kbuild-all (as used by Philip at Intel)