### PR TITLE
Kismet separate formula creation

### DIFF
--- a/kmax/arch.py
+++ b/kmax/arch.py
@@ -223,7 +223,7 @@ class Arch:
       ensure_then_dump(rev_dep_path,  self.get_rev_dep,  self.dump_rev_dep)
       ensure_then_dump(selects_path,  self.get_selects,  self.dump_selects)
 
-  def __init__(self, name: str, linux_ksrc=None, arch_dir=None, is_kclause_composite=False, verify_linux_ksrc=True, kextract_version=None, loggerLevel=logging.INFO):
+  def __init__(self, name: str, linux_ksrc=None, arch_dir=None, is_kclause_composite=False, verify_linux_ksrc=True, kextract_version=None, loggerLevel=logging.INFO, kclause_args=None):
     """Create an Arch instance.
 
     Arguments:
@@ -242,9 +242,12 @@ class Arch:
     on this flag. If kclause file doesn't exist, the delayed dump will be composite
     or not depending on the flag.
     loggerLevel -- Logger level.
+    kclause_args -- additional arguments, as a list, to kclause (None by default)
     """
     self.__logger=getLogger(name="Arch(%s)" % name, level=loggerLevel)
     self.name=name
+
+    self.__kclause_args = kclause_args
     
     #
     # Formulas
@@ -952,6 +955,8 @@ class Arch:
     assert self.__kextract != None
 
     command = ["kclause", "--remove-orphaned-nonvisible" ]
+    if self.__kclause_args != None: command = command + self.__kclause_args
+    # TODO: disable tristate handling when requested, i.e., for kismet
     self.__logger.debug("Running kclause tool to generate kclause formulas.")
     proc_stdout, _, ret_code = self.__run_command(command, self.__kextract.encode(), capture_stderr=False)
     

--- a/kmax/kclause
+++ b/kmax/kclause
@@ -70,6 +70,9 @@ if __name__ == '__main__':
   argparser.add_argument('--selects-only',
                          action="store_true",
                          help="""Print selects only.""")
+  argparser.add_argument('--disable-tristate-support',
+                         action="store_true",
+                         help="""Don't model tristate options with separate y and m Boolean variables.""")
   argparser.add_argument('--remove-all-nonvisibles',
                          action="store_true",
                          help="""whether to leave only those config vars that can be selected by the user.  this is defined as config vars that have a kconfig prompt.""")
@@ -120,6 +123,9 @@ if __name__ == '__main__':
   normal_dep_only = args.normal_dependencies_only
   reverse_dep_only = args.reverse_dependencies_only
   selects_only = args.selects_only
+  disable_tristate_support = args.disable_tristate_support
+
+  allow_tristate = not disable_tristate_support
 
   if unselectable or selectable:
     # don't do output, which won't make much sense for --(un)selectable
@@ -201,7 +207,7 @@ if __name__ == '__main__':
       pass
 
   def convert_and_add_clause(varname, expr):
-    add_clause(varname, expression_converter.convert_to_z3(expr))
+    add_clause(varname, expression_converter.convert_to_z3(expr, allow_tristate=not disable_tristate_support))
 
   def pretty_printer(expr, stream=sys.stdout):
     depth = 0
@@ -412,9 +418,12 @@ if __name__ == '__main__':
   if normal_dep_only or reverse_dep_only or selects_only:
     if not quiet: sys.stderr.write("[STEP 2/3] converting the constraints to smtlib2 format..\n")
 
+    if not disable_tristate_support:
+      sys.stderr.write("note that tristate support is not enabled for --normal-dependencies-only, --reverse-dependencies-only, or --selects-only, since supporting tristate requires additional global constraints\n")
+
     # Undeclared symbols will be "FOO" instead of CONFIG_FOO
     def is_sym_declared(sym_name):
-      return not z3.is_false( expression_converter.convert_to_z3(sym_name + " and 1") )
+      return not z3.is_false( expression_converter.convert_to_z3(sym_name + " and 1", allow_tristate=False) )
 
     def convert_str_expr_to_smtlib2(str_expr):
       # Always and with 1 to eliminate "SYM" cases
@@ -1099,7 +1108,7 @@ if __name__ == '__main__':
         if debug_expressions: sys.stderr.write("unconditional visible %s\n" % (visible_expr))
         if debug_expressions: sys.stderr.write("conditional nonvisible %s\n" % (cond_nonvisible_expr))
         if debug_expressions: sys.stderr.write("unconditional nonvisible %s\n" % (nonvisible_expr))
-        if debug_expressions: sys.stderr.write("unconditional nonvisible z3 %s\n" % (expression_converter.convert_to_z3(nonvisible_expr) if nonvisible_expr is not None else None))
+        if debug_expressions: sys.stderr.write("unconditional nonvisible z3 %s\n" % (expression_converter.convert_to_z3(nonvisible_expr, allow_tristate=not disable_tristate_support) if nonvisible_expr is not None else None))
 
         if cond_visible_expr != None and cond_nonvisible_expr != None:
           final_expr = disjunction(cond_visible_expr, cond_nonvisible_expr)
@@ -1112,7 +1121,7 @@ if __name__ == '__main__':
 
         if final_expr != None:
           if debug_expressions: sys.stderr.write("%s final expression is %s\n" % (var, final_expr))
-          if debug_expressions: sys.stderr.write("%s final expression z3 is %s\n" % (var, expression_converter.convert_to_z3(final_expr) if final_expr is not None else None))
+          if debug_expressions: sys.stderr.write("%s final expression z3 is %s\n" % (var, expression_converter.convert_to_z3(final_expr, allow_tristate=not disable_tristate_support) if final_expr is not None else None))
           defined_vars.add(var)
           convert_and_add_clause(var, final_expr)
         else:

--- a/kmax/kismet
+++ b/kmax/kismet
@@ -263,7 +263,7 @@ if __name__ == '__main__':
   argparser.add_argument('--formulas',
                         type=str,
                         default=None,
-                        help="""Path to the architecture formulas directory which contain kextract file and kclause files.  Defaults to \"LINUX_KSRC/.kmax/kclause/ARCHNAME\" (LINUX_KSRC from --linux-ksrc and ARCHNAME from --arch).""")
+                        help="""Path to the architecture formulas directory which contain kextract file and kclause files.  Defaults to \"LINUX_KSRC/.kismet/kclause/ARCHNAME\" (LINUX_KSRC from --linux-ksrc and ARCHNAME from --arch).""")
   argparser.add_argument('--linux-ksrc',
                         type=str,
                         default="./",
@@ -409,7 +409,7 @@ if __name__ == '__main__':
   #
   # Set default value for formulas if not specified
   if not formulas_arg:
-    formulas_arg = os.path.join(linux_ksrc, ".kmax/")
+    formulas_arg = os.path.join(linux_ksrc, ".kismet/")
 
   # Get the build system id, which names the formulas cache subdirectory
   info("Computing the build system id for the Linux source..")

--- a/kmax/kismet
+++ b/kmax/kismet
@@ -423,7 +423,8 @@ if __name__ == '__main__':
     assert arch != None
     return os.path.join(formulas, "kclause", arch)
 
-  arch = Arch(arch_name, linux_ksrc=linux_ksrc, arch_dir=get_arch_formulas_dir(formulas, arch_name), loggerLevel=kismet_log_level)
+  arch = Arch(arch_name, linux_ksrc=linux_ksrc, arch_dir=get_arch_formulas_dir(formulas, arch_name), loggerLevel=kismet_log_level, kclause_args=["--disable-tristate-support"])
+  # don't use the kclause tristate extension, since we are using partial formulas that don't compose properly
   
   info("Kismet will analyze the select constructs of the architecture \"%s\" for unmet direct dependency." % arch.name)
   info("All times reported are measured using Python's time.perf_counter() utility.")


### PR DESCRIPTION
The new kclause support for modeling tests of specific tristate values works for the default kclause output.  But kismet uses two custom formula extractions (normal-dependencies and selects) that have not yet been updated to use the tristate values.  Since the tristate value modeling requires some global support, handling this for kismet's formula extractions will require additional effort.

This additionally adds an option to disable kclause's new tristate modeling, which is used by kismet.  It also moves kismet's formula folder to .kismet instead of .kmax.
