### PR TITLE
Handle changed file permissions

### DIFF
--- a/kmax/common.py
+++ b/kmax/common.py
@@ -111,6 +111,7 @@ class FileChangeType(enum.Enum):
     MOVED_ONLY = 3 # file was moved but the content didn't change
     MOVED_MODIFIED = 4 # file was moved and the content was modified
     MODIFIED_ONLY = 5 # content was modified but the file wasn't moved
+    PERMISSION_CHANGED = 6 # file permissions changed
 
     @classmethod
     def getType(cls, diff):
@@ -134,4 +135,6 @@ class FileChangeType(enum.Enum):
             # both before and after instead of none_file name. See
             # e8bf1f522aee3b3e1e7658e8f224dca1d88c3338 for the Linux kernel.
             return FileChangeType.REMOVED
+        elif "new file mode" or "new mode" in diff.text:
+            return FileChangeType.PERMISSION_CHANGED
         else: assert False # all cases are covered above

--- a/kmax/patch.py
+++ b/kmax/patch.py
@@ -30,7 +30,7 @@ def is_interesting_diff(diff) -> bool:
   if change_type != FileChangeType.CREATED        and \
      change_type != FileChangeType.MODIFIED_ONLY  and \
      change_type != FileChangeType.MOVED_MODIFIED:
-    # otherwise, it is REMOVED or MOVED_ONLY; for which we don't create configs
+    # otherwise, it is REMOVED, PERMISSION_CHANGED, or MOVED_ONLY; for which we don't create configs
     return False
 
   return is_maybe_kernel(diff['new_path'])


### PR DESCRIPTION
Previously, kmax's `FileChangeType` class did not account for file permission changes in diff files, which caused an `AssertionError` to appear in those cases. This pull request simply adds another type, `PERMISSION_CHANGED`. Logic elsewhere isn't changed in the code.

### Important notes:
- The change assumes that permission changes "aren't interesting" and aren't worth setting configuration options for.
- I changed the `FileChangeType` class's tabs to spaces to align with modern Python code styling.
- The pull request has only been tested on the steps under #274. It is not tested any further, so feel free to request changes.