### PR TITLE
Allow file type changes if file is classified as MOVED_MODIFIED

### DIFF
--- a/kmax/patch.py
+++ b/kmax/patch.py
@@ -104,7 +104,11 @@ def summarize_patch(patch: str, str_change_type=False) -> list:
     if removed_lines: diff_summary["removed_lines"] = removed_lines
 
     if old_path and new_path:
-      assert SourceFileType.get_file_type(old_path) == SourceFileType.get_file_type(new_path)
+      # allow file type change for MOVED_MODIFIED
+      if change_type == FileChangeType.MOVED_MODIFIED:
+        diff_summary["file_type"] = SourceFileType.get_file_type(new_path)
+      else:  # for MOVED_ONLY and other cases
+        assert SourceFileType.get_file_type(old_path) == SourceFileType.get_file_type(new_path)
 
     # set file type
     if old_path:

--- a/kmax/patch.py
+++ b/kmax/patch.py
@@ -103,15 +103,17 @@ def summarize_patch(patch: str, str_change_type=False) -> list:
     if added_lines: diff_summary["added_lines"] = added_lines
     if removed_lines: diff_summary["removed_lines"] = removed_lines
 
+    # set file type
     if old_path and new_path:
       # allow file type change for MOVED_MODIFIED
       if change_type == FileChangeType.MOVED_MODIFIED:
         diff_summary["file_type"] = SourceFileType.get_file_type(new_path)
       else:  # for MOVED_ONLY and other cases
         assert SourceFileType.get_file_type(old_path) == SourceFileType.get_file_type(new_path)
+        diff_summary["file_type"] = SourceFileType.get_file_type(new_path)
 
-    # set file type
-    if old_path:
+    # if only old_path/new_path provided, set to their file type
+    elif old_path:
       diff_summary["file_type"] = SourceFileType.get_file_type(old_path)
     elif new_path:
       diff_summary["file_type"] = SourceFileType.get_file_type(new_path)


### PR DESCRIPTION
At times, the Linux kernel can encounter modifications to file types that will change their `SourceFileType` from `SOURCE` to `OTHER`, as seen in #256:
```
diff --git a/arch/s390/crypto/crc32be-vx.S b/arch/s390/crypto/crc32be-vx.c
similarity index 56%
rename from arch/s390/crypto/crc32be-vx.S
rename to arch/s390/crypto/crc32be-vx.c
```
This change to the code should account for those modifications, provided that the `FileChangeType` is already set as `MOVED_MODIFIED`. 

### Important notes:
* At this time, the code is _**lightly tested.**_ The change allows the code to get further in the set of commits provided in #256 by addressing the AssertionError.
     * Without the fix from #275, `kmax` will run into the same error detailed in #274. 
     * ~~That being said, it's worth noting that applying the commits brought up in the issue will cause the program run into a different error after applying this change. I currently believe the error is unrelated, but I will continue debugging & testing before turning this into a full PR (some debug prints added as well):~~
```
srcfile: drivers/net/ethernet/hisilicon/hns3/hns3pf/hclge_main.c, linux_ksrc: ./
srcfile_fullpath: ./drivers/net/ethernet/hisilicon/hns3/hns3pf/hclge_main.c
srcfile: drivers/net/ethernet/hisilicon/hns3/hns3pf/hclge_mbx.c, linux_ksrc: ./
srcfile_fullpath: ./drivers/net/ethernet/hisilicon/hns3/hns3pf/hclge_mbx.c
srcfile: drivers/net/ethernet/hisilicon/hns3/hns3pf/hclge_ptp.c, linux_ksrc: ./
srcfile_fullpath: ./drivers/net/ethernet/hisilicon/hns3/hns3pf/hclge_ptp.c
srcfile: drivers/net/ethernet/hisilicon/hns3/hns3pf/hclge_tm.c, linux_ksrc: ./
srcfile_fullpath: ./drivers/net/ethernet/hisilicon/hns3/hns3pf/hclge_tm.c
srcfile: drivers/net/ethernet/hisilicon/hns3/hns3vf/hclgevf_main.c, linux_ksrc: ./
srcfile_fullpath: ./drivers/net/ethernet/hisilicon/hns3/hns3vf/hclgevf_main.c
srcfile: drivers/net/ethernet/i825xx/sun3_82586.c, linux_ksrc: ./
srcfile_fullpath: ./drivers/net/ethernet/i825xx/sun3_82586.c
Traceback (most recent call last):
  File "/home/alexei/IDEProjects/PyCharmProjects/kmax/venv/bin/klocalizer", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/alexei/IDEProjects/PyCharmProjects/kmax/kmax/klocalizer", line 1728, in <module>
    klocalizerCLI()
  File "/home/alexei/IDEProjects/PyCharmProjects/kmax/kmax/klocalizer", line 815, in klocalizerCLI
    root_cb = SyntaxAnalysis.get_conditional_blocks_of_file(srcfile_fullpath)
  File "/home/alexei/IDEProjects/PyCharmProjects/kmax/kmax/superc.py", line 762, in get_conditional_blocks_of_file
    cb = SyntaxAnalysis.get_conditional_blocks(content, line_count)
  File "/home/alexei/IDEProjects/PyCharmProjects/kmax/kmax/superc.py", line 714, in get_conditional_blocks
    stack[-1].sub_block_groups.append([new_cb])
IndexError: list index out of range
```

I confirmed that the above error is an entirely separate bug in #277. 