### PR TITLE
Add fix for interpreting directives without spaces

### DIFF
--- a/kmax/superc.py
+++ b/kmax/superc.py
@@ -646,7 +646,21 @@ class SyntaxAnalysis:
             if in_comment:
                 analyzed_tokens[line_num].append({token: "comment"})
             elif in_preprocessor:
-                analyzed_tokens[line_num].append({token: "preprocessor"})
+                # handle case where no space between directive and parenthesis
+                found_directive = False  # track if directive found
+                for directive in ['if', 'ifdef', 'ifndef', 'elif', 'else', 'endif']:
+                    if token.startswith(directive + '('):
+                        directive_token = directive
+                        remaining_token = token[len(directive):]  # capture remaining part by slicing at length of directive
+                        analyzed_tokens[line_num].append({directive_token: "preprocessor"})  # add directive
+                        if remaining_token:
+                            analyzed_tokens[line_num].append({remaining_token: "preprocessor"}) # add remaining token
+                            found_directive = True
+                        break
+
+                # if no directive found: just add token as whole
+                if not found_directive:
+                    analyzed_tokens[line_num].append({token: "preprocessor"})
             else:
                 analyzed_tokens[line_num].append({token: "c"})
 


### PR DESCRIPTION
As demonstrated in #277, kmax's SuperC-less tokenizer (`kmax/superc.py`) currently doesn't account for conditional directives without a space between the directive and the parenthesis, such as:
```
netif_stop_queue(dev);

#if(NUM_XMIT_BUFFS > 1)  //affected line
	if(test_and_set_bit(0,(void *) &p->lock)) {
```

## Considerations
The issue lies in how the `get_tokens()` method tokenizes parts of the C code. Currently, the function is a bit simplistic in its logic for separating different parts of comments or directives from one another, in particular, it relies heavily on spaces to start a new token:
```
for c in s:
            # append the existing buffered token when we reach a space or tab
            if c == ' ' or c == '\t':
                if buf != "":
                    token_list.append((buf, line_num))
                    buf = ""
            else:
```
That being said, it lacks a system for determining the impact of a starter parenthesis on a directive, and given the existing complexity of the tokenizer, I'm worried about changing current logic too much. If I add logic for tokenizing at parentheses as follows:
```
 elif c == '#' or c == '\'' or c == '"' or c == '\\' or c == '(' or c == ')' or (c == '/' and prev_char == '/') or (prev_char == '/' and c == '*') or (prev_char == '*' and c == '/'):
                    if buf != '/' and buf != '*' and buf != "":
```

that means that the tokenizer would treat each parenthesis as a separate token, which **would likely require some other changes in kmax's logic for checking conditional directives, and could cause other bugs.**

For the time being, I've landed on a safer workaround. By splitting tokens in analyze_c_tokens if currently in a conditional directive, we safely fix the bug without replacing too much existing logic.

I'm confident in the current fix's stability and would be open to merging it in its current state. That being said, we could explore modifying kmax logic further, either purely in `get_tokens()` or elsewhere, to account for this bug more cleanly in the future.

## Testing
* I tested this fix on an unrelated commit to the bug filed, [b4cd80b0338945a94972ac3ed54f8338d2da2076](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=b4cd80b0338945a94972ac3ed54f8338d2da2076) with the existing version of `4.8rc4` from the repository as well as my fix on `master`.
* I found that when applying klocalizer and koverage onto an `allnoconfig`, both worked successfully, and there were **no differences between** `coverage_results.json` (from `koverage`) and `coverage_report.json` (from `klocalizer`), but there were marginal differences between the two generated configuration files. 