### PR TITLE
fix implicit-[int/declaration] errors in bconf.tab.c

### DIFF
--- a/kextractors/kextractor-3.19/bconf.tab.c
+++ b/kextractors/kextractor-3.19/bconf.tab.c
@@ -118,6 +118,7 @@ struct linked_list {
   void *data;
 };
 
+void bconferror(char *msg);
 
 void
 add_config_var(char *var, enum symbol_type stype, char *def, struct linked_list *dep_list)
@@ -2061,7 +2062,7 @@ yyreturn:
 
 char *filename;
 
-bconf_parse(char *file)
+void bconf_parse(char *file)
 {
 	struct symbol *sym;
 	int i;
@@ -2104,7 +2105,7 @@ bconf_parse(char *file)
 	/* sym_set_change_count(1); */
 }
 
-bconf_test_lexer(char *file)
+void bconf_test_lexer(char *file)
 {
   int t;
 
@@ -2116,7 +2117,7 @@ bconf_test_lexer(char *file)
   }
 }
 
-bconferror(char *msg) {
+void bconferror(char *msg) {
   fprintf(stderr, "error:%s:%d: %s\n", filename, bconflineno, msg);
   exit(1);
 }

--- a/kextractors/kextractor-3.2/bconf.tab.c
+++ b/kextractors/kextractor-3.2/bconf.tab.c
@@ -118,6 +118,7 @@ struct linked_list {
   void *data;
 };
 
+void bconferror(char *msg);
 
 void
 add_config_var(char *var, enum symbol_type stype, char *def, struct linked_list *dep_list)
@@ -2061,7 +2062,7 @@ yyreturn:
 
 char *filename;
 
-bconf_parse(char *file)
+void bconf_parse(char *file)
 {
 	struct symbol *sym;
 	int i;
@@ -2104,7 +2105,7 @@ bconf_parse(char *file)
 	/* sym_set_change_count(1); */
 }
 
-bconf_test_lexer(char *file)
+void bconf_test_lexer(char *file)
 {
   int t;
 
@@ -2116,7 +2117,7 @@ bconf_test_lexer(char *file)
   }
 }
 
-bconferror(char *msg) {
+void bconferror(char *msg) {
   fprintf(stderr, "error:%s:%d: %s\n", filename, bconflineno, msg);
   exit(1);
 }

--- a/kextractors/kextractor-4.12.8/bconf.tab.c
+++ b/kextractors/kextractor-4.12.8/bconf.tab.c
@@ -118,6 +118,7 @@ struct linked_list {
   void *data;
 };
 
+void bconferror(char *msg);
 
 void
 add_config_var(char *var, enum symbol_type stype, char *def, struct linked_list *dep_list)
@@ -2061,7 +2062,7 @@ yyreturn:
 
 char *filename;
 
-bconf_parse(char *file)
+void bconf_parse(char *file)
 {
 	struct symbol *sym;
 	int i;
@@ -2104,7 +2105,7 @@ bconf_parse(char *file)
 	/* sym_set_change_count(1); */
 }
 
-bconf_test_lexer(char *file)
+void bconf_test_lexer(char *file)
 {
   int t;
 
@@ -2116,7 +2117,7 @@ bconf_test_lexer(char *file)
   }
 }
 
-bconferror(char *msg) {
+void bconferror(char *msg) {
   fprintf(stderr, "error:%s:%d: %s\n", filename, bconflineno, msg);
   exit(1);
 }


### PR DESCRIPTION
Installation with latest python*, pip*, etc is causing no return type and implicit declaration issues. Fixing those by adding explicit return types and declaring `bconferror` at the top

Closes: https://github.com/paulgazz/kmax/issues/300