### PR TITLE
Check for errors in the syntax analysis algorithm in superc.py

### DIFF
--- a/kmax/klocalizer
+++ b/kmax/klocalizer
@@ -843,29 +843,35 @@ def klocalizerCLI():
         srcfile_fullpath = os.path.join(linux_ksrc, srcfile)
         assert os.path.isfile(srcfile_fullpath)
         logger.debug("Doing syntax analysis on \"%s\" to get constrained line ranges.\n" % srcfile)
-        
-        root_cb = SyntaxAnalysis.get_conditional_blocks_of_file(srcfile_fullpath)
 
-        # Check if given line list is valid for the file.
-        line_count = root_cb.end_line - 1 #< Root (dummy) ConditionalBlock has special end_line value.
-        for l in line_list:
-          if not 0 < l <= line_count:
-            logger.error("Requested line (%s) is invalid for the source file (\"%s\")\n" % (l, srcfile))
-            exit(12)
+        try:
+          root_cb = SyntaxAnalysis.get_conditional_blocks_of_file(srcfile_fullpath)
+          
+          # Check if given line list is valid for the file.
+          line_count = root_cb.end_line - 1 #< Root (dummy) ConditionalBlock has special end_line value.
+          for l in line_list:
+            if not 0 < l <= line_count:
+              logger.error("Requested line (%s) is invalid for the source file (\"%s\")\n" % (l, srcfile))
+              exit(12)
 
-        # Get the ConditionalBlock that cover the requested lines.
-        nodes = [root_cb.retrieve_deepest_block(l) for l in line_list]
-        assert len(nodes) == len(line_list)
-        # Get the constrained lines only (those that don't belong to dummy root)
-        # Unconstrained lines will already build with the file.
-        new_line_list = []
-        for l, n in zip(line_list, nodes):
-          if n == root_cb:
-            global_scope_lines[unit] = global_scope_lines.get(unit, set()).union([l])
-          else:
-            new_line_list.append(l)
-        removed_lines = len(line_list) - len(new_line_list)
-        assert removed_lines >= 0
+          # Get the ConditionalBlock that cover the requested lines.
+          nodes = [root_cb.retrieve_deepest_block(l) for l in line_list]
+          assert len(nodes) == len(line_list)
+          # Get the constrained lines only (those that don't belong to dummy root)
+          # Unconstrained lines will already build with the file.
+          new_line_list = []
+          for l, n in zip(line_list, nodes):
+            if n == root_cb:
+              global_scope_lines[unit] = global_scope_lines.get(unit, set()).union([l])
+            else:
+              new_line_list.append(l)
+          removed_lines = len(line_list) - len(new_line_list)
+          assert removed_lines >= 0
+        except:
+          logger.warning(f"Syntax analysis of {srcfile} failed.\n")
+          new_line_list = list(line_list)
+          removed_lines = []
+
         logger.debug(
           """Syntax analysis for \"%s\" found %s unconstrained lines, """
           """%s lines are remaining for presence condition analysis.\n"""


### PR DESCRIPTION
The current implementation of the C tokenizer is broken, in particular with the handling of quotes.  For instance, in Linux v6.17:

klocalizer -a x86_64 --repair .config --include-mutex init/main.c:[1480,1481]

- init/main.c:354:q = strpbrk(val, " \t\r\n") ? "\"" : ""; init/main.c:365:#undef rest
- init/main.c:377:#else	/* !CONFIG_BOOT_CONFIG */
- init/main.c:1238:#else

On line 354 \" is not properly handled as an escaped quote.