### PR TITLE
Remove dd and networkx version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ setup(
         'enum34',
         'regex',
         'z3-solver',
-        'dd==0.5.7', # dd requires networkx >= 2.4 starting from 0.6.0
-        'networkx==2.2', # for dd to work on python2
+        'dd',
+        'networkx',
         'requests',
         'whatthepatch',
         'packaging',


### PR DESCRIPTION
These requirements were for python2, which is no longer supported.

Moreover, this now breaks the build.  Fixes #306.